### PR TITLE
Fixed gamesheet title bar, better font and description

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -213,6 +213,32 @@
   min-height: 100vh;
 }
 
+/* Match .game-sheet-main flex proportions: back over sidebar col, title over both roster cols */
+.game-sheet-page > .game-sheet-page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 3rem;
+}
+
+.game-sheet-page > .game-sheet-page-header > .game-sheet-page-header-back {
+  flex: 1 1 320px;
+  min-width: 320px;
+}
+
+.game-sheet-page > .game-sheet-page-header > .game-sheet-page-header-title {
+  flex: 2 1 0;
+  min-width: min(100%, 280px);
+  display: flex;
+  justify-content: center;
+}
+
+.game-sheet-page > .game-sheet-page-header > .game-sheet-page-header-title h1 {
+  text-align: center;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
 .game-sheet-header h2 {
   margin-top: 0;
   margin-bottom: 0.75rem;
@@ -999,8 +1025,10 @@
   align-items: flex-start;
 }
 
-.page-header a:first-child {
-  font-size: 0.95rem;
+/* Back / nav link in page headers (gamesheet wraps link in .game-sheet-page-header-back) */
+.page-header a:first-child,
+.page-header .game-sheet-page-header-back a {
+  font-size: 0.8rem;
 }
 
 .client-status-line {

--- a/ui/src/pages/GameSheet.tsx
+++ b/ui/src/pages/GameSheet.tsx
@@ -490,11 +490,22 @@ export function GameSheet() {
     }
   };
 
+  const sheetTitlePrefix = [aggregate.level, aggregate.gender]
+    .filter((s): s is string => typeof s === "string" && s.trim().length > 0)
+    .join(" ");
+
   return (
     <div className="page game-sheet-page">
-      <header className="page-header">
-        <Link to={gameDayId ? `/game-days/${gameDayId}` : "/"}>← Back to game day</Link>
-        <h1>{aggregate.awayTeamName} vs {aggregate.homeTeamName}</h1>
+      <header className="page-header game-sheet-page-header">
+        <div className="game-sheet-page-header-back">
+          <Link to={gameDayId ? `/game-days/${gameDayId}` : "/"}>← Back to game day</Link>
+        </div>
+        <div className="game-sheet-page-header-title">
+          <h1>
+            {sheetTitlePrefix ? `${sheetTitlePrefix}: ` : ""}
+            {aggregate.homeTeamName} vs {aggregate.awayTeamName}
+          </h1>
+        </div>
       </header>
 
       <div className="game-sheet-main">


### PR DESCRIPTION
# Summary
**Gamesheet title**: Level Gender: Home vs Away when level/gender exist (from aggregate); otherwise Home vs Away only.
**Header layout**: title centered over the two roster columns; back link stays in the sidebar column (App.css flex matches game-sheet-main).
**Title** underlined with slight underline offset.
Smaller back / first nav links in page-header everywhere (including gamesheet).
## Files
ui/src/pages/GameSheet.tsx — title + header wrappers
ui/src/App.css — gamesheet header flex, underline, 0.8rem nav links
## Check
Game with level/gender → colon prefix, centered title, underline.
Game without → matchup only.
Other pages → back link text smaller.
