### PR TITLE
Added new game levels

### DIFF
--- a/ui/src/pages/AddGame.tsx
+++ b/ui/src/pages/AddGame.tsx
@@ -7,7 +7,7 @@ import {
 } from "../components/DatabaseUnavailable";
 import type { CreateGameInput } from "../types/gameDay";
 
-const LEVELS = ["Varsity", "JV", "14U", "16U", "18U", ""];
+const LEVELS = ["Varsity", "JV", "10U", "12U", "14U", "16U", "18U", "Masters", ""];
 const GENDERS = ["Boys", "Girls", "Co-ed", ""];
 const GAME_TYPES = ["League", "Tournament", "Scrimmage", "Practice", ""];
 const DEFAULT_QUARTER_MS = 8 * 60 * 1000;

--- a/ui/src/pages/EditGame.tsx
+++ b/ui/src/pages/EditGame.tsx
@@ -7,7 +7,7 @@ import {
 } from "../components/DatabaseUnavailable";
 import type { UpdateGameInput } from "../types/gameDay";
 
-const LEVELS = ["Varsity", "JV", "14U", "16U", "18U", ""];
+const LEVELS = ["Varsity", "JV", "10U", "12U", "14U", "16U", "18U", "Masters", ""];
 const GENDERS = ["Boys", "Girls", "Co-ed", ""];
 const GAME_TYPES = ["League", "Tournament", "Scrimmage", "Practice", ""];
 const MS_PER_MIN = 60 * 1000;


### PR DESCRIPTION
## Summary
Adds 10U, 12U, and Masters to the Level dropdown on add and edit game so game-day metadata matches common age groups and masters play.

## Changes
Updates the shared LEVELS list in AddGame.tsx and EditGame.tsx (youth ages ordered 10U → 18U; Masters after Varsity/JV and youth tiers).

## Notes
level remains a string in the API/database; no migration.