### PR TITLE
31 edit game day settings

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^1.7.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1",
@@ -2683,6 +2684,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/minimatch": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^1.7.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1",

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -1247,8 +1247,62 @@
   font-size: 1.2rem;
 }
 
-.games-section .btn.primary {
+/* Only the Add game control below the table; not row action buttons (they use .btn.primary too). */
+.games-section > .btn.primary {
   margin-top: 0.5rem;
+}
+
+.games-section .table th:nth-child(n + 8) {
+  text-align: center;
+}
+
+.games-section .table td.games-action-cell {
+  vertical-align: middle;
+  text-align: center;
+}
+
+.games-section .table .btn.btn-games-row-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 4.25rem;
+  height: 1.65rem;
+  min-height: 1.65rem;
+  padding: 0.2rem 0.3rem;
+  font-size: 0.8rem;
+  line-height: 1;
+  vertical-align: middle;
+}
+
+.games-section .btn.btn-roster-icon {
+  background: #e57373;
+  color: #fff;
+}
+
+.games-section .btn.btn-roster-icon:hover {
+  background: #ef5350;
+  color: #fff;
+}
+
+@media (prefers-color-scheme: light) {
+  .games-section .btn.btn-roster-icon {
+    background: #e57373;
+    color: #fff;
+  }
+
+  .games-section .btn.btn-roster-icon:hover {
+    background: #e53935;
+    color: #fff;
+  }
+}
+
+.games-section .btn.btn-settings-gear {
+  color: #646cff;
+}
+
+.games-section .btn.btn-settings-gear:hover {
+  color: #535bf2;
 }
 
 .roster-panel-subtitle {

--- a/ui/src/pages/GameDayDetail.tsx
+++ b/ui/src/pages/GameDayDetail.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { ClipboardList, Settings, UserRoundCheck } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import { api } from "../api/client";
 import type { GameDay, GameOnDay } from "../types/gameDay";
@@ -29,7 +30,7 @@ export function GameDayDetail() {
     <div className="page">
       <header className="page-header">
         <Link to="/">← Game Days</Link>
-        <h1>{gameDay.date} — {gameDay.location}</h1>
+        <h1>{gameDay.date} @ {gameDay.location}</h1>
         <Link to={`/game-days/${gameDay.id}/edit`} className="btn secondary">
           Edit day
         </Link>
@@ -49,7 +50,7 @@ export function GameDayDetail() {
               <th>Gender</th>
               <th>Roster</th>
               <th>Game sheet</th>
-              <th></th>
+              <th>Settings</th>
             </tr>
           </thead>
           <tbody>
@@ -96,24 +97,35 @@ function GameRow({
       <td>{game.level ?? "—"}</td>
       <td>{game.gameType ?? "—"}</td>
       <td>{game.gender ?? "—"}</td>
-      <td>
+      <td className="games-action-cell">
         <Link
           to={`/game-days/${gameDayId}/games/${game.id}/roster`}
-          className="btn secondary btn-compact"
+          className="btn btn-compact btn-games-row-action btn-roster-icon"
+          aria-label="Edit Roster"
+          title="Edit Roster"
         >
-          Roster
+          <UserRoundCheck size={16} strokeWidth={2} aria-hidden />
         </Link>
       </td>
-      <td>
+      <td className="games-action-cell">
         <Link
           to={`/game-days/${gameDayId}/games/${game.id}/sheet`}
-          className="btn secondary btn-compact"
+          className="btn primary game-sheet-button btn-compact btn-games-row-action"
+          aria-label="Edit Game Sheet"
+          title="Edit Game Sheet"
         >
-          Game sheet
+          <ClipboardList size={16} strokeWidth={2} aria-hidden />
         </Link>
       </td>
-      <td>
-        <Link to={`/game-days/${gameDayId}/games/${game.id}/edit`}>Edit</Link>
+      <td className="games-action-cell">
+        <Link
+          to={`/game-days/${gameDayId}/games/${game.id}/edit`}
+          className="btn secondary btn-compact btn-games-row-action btn-settings-gear"
+          aria-label="Edit game"
+          title="Edit game"
+        >
+          <Settings size={16} strokeWidth={2} aria-hidden />
+        </Link>
       </td>
     </tr>
   );


### PR DESCRIPTION
## Overview
Refines the game day detail games table: row actions are compact Lucide icon buttons with colors aligned to existing UI accents, consistent sizing and alignment, and clearer hover / accessible names for roster and game sheet.

### User-facing changes

- Roster: UserRoundCheck icon on a light red filled control; tooltip and aria-label: “Edit Roster”.
- Game sheet: ClipboardList on the existing green game sheet primary style; tooltip and aria-label: “Edit Game Sheet”.
- Settings / edit: Settings (gear) on secondary styling with primary blue icon color (#646cff / #535bf2 hover); “Edit game” for tooltip and aria-label.
- Layout: Roster, Game sheet, and Settings columns share a fixed width/height action control, centered in the cell; vertical alignment across the row is fixed so the green button is not offset (see below).
Implementation notes
- Adds lucide-react and uses tree-shaken named imports. [ui/src/App.css]:
`.btn-games-row-action` for shared dimensions; .btn-roster-icon, .btn-settings-gear; .games-action-cell for cell alignment.
margin-top on .btn.primary inside the games section is limited to .games-section > .btn.primary so Add game keeps spacing but table primary buttons are not pushed down.`

Open a game day with multiple games; confirm the three icon buttons align in each row and match expected colors.
Hover roster, game sheet, and settings; confirm Edit Roster, Edit Game Sheet, and Edit game tooltips.
Confirm Add game still has appropriate spacing below the table.