### PR TITLE
Game progress edit delete or insert modal

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,13 +6,14 @@
   "main": "dist/server.js",
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/server.js",
     "lint": "echo \"no linter configured\"",
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
     "prisma:studio": "prisma studio",
-    "db:seed": "tsx prisma/seed.ts"
+    "db:seed": "tsx prisma/seed.ts",
+    "test": "tsx --test src/services/gameEventRerun.sort.test.ts"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/server/src/routes/games.ts
+++ b/server/src/routes/games.ts
@@ -15,6 +15,7 @@ import {
   updateGameDayBodySchema,
   replaceRosterBodySchema,
   scoreCommandBodySchema,
+  eventLogRebuildBodySchema,
 } from "../schemas/game.schemas";
 import { GameService } from "../services/game.service";
 
@@ -133,6 +134,12 @@ export async function registerGameRoutes(app: FastifyInstance) {
     const params = gameIdParamSchema.parse(request.params);
     const body = scoreCommandBodySchema.parse(request.body);
     return service.applyScoreCommand(params.id, body);
+  });
+
+  app.post("/games/:id/event-log/rebuild", async (request) => {
+    const params = gameIdParamSchema.parse(request.params);
+    const body = eventLogRebuildBodySchema.parse(request.body);
+    return service.rebuildGameFromEventLog(params.id, body.events);
   });
 
   // Game clock

--- a/server/src/schemas/game.schemas.ts
+++ b/server/src/schemas/game.schemas.ts
@@ -1,3 +1,4 @@
+import { GameEventType } from ".prisma/client";
 import { z } from "zod";
 
 // Game day
@@ -92,6 +93,18 @@ export const scoreCommandBodySchema = z.object({
   overtime: z.boolean().optional(),
 });
 
+export const eventLogRebuildRowSchema = z.object({
+  id: z.string().cuid().optional(),
+  eventType: z.nativeEnum(GameEventType),
+  payload: z.unknown().optional(),
+  createdAt: z.string(),
+  source: z.string().optional(),
+});
+
+export const eventLogRebuildBodySchema = z.object({
+  events: z.array(eventLogRebuildRowSchema).min(1),
+});
+
 export type CreateGameDayBody = z.infer<typeof createGameDayBodySchema>;
 export type UpdateGameDayBody = z.infer<typeof updateGameDayBodySchema>;
 export type GameDayIdParams = z.infer<typeof gameDayIdParamSchema>;
@@ -105,4 +118,5 @@ export type CreateExclusionBody = z.infer<typeof createExclusionBodySchema>;
 export type TriggerHornBody = z.infer<typeof triggerHornBodySchema>;
 export type ReplaceRosterBody = z.infer<typeof replaceRosterBodySchema>;
 export type ScoreCommandBody = z.infer<typeof scoreCommandBodySchema>;
+export type EventLogRebuildBody = z.infer<typeof eventLogRebuildBodySchema>;
 

--- a/server/src/services/game.service.ts
+++ b/server/src/services/game.service.ts
@@ -7,6 +7,11 @@ import {
   type DeviceSummary,
 } from "./deviceCapabilities";
 import { env } from "../config/env";
+import {
+  rerunGameEventLog,
+  sortEventsForRerun,
+  type RebuildEventInput,
+} from "./gameEventRerun";
 
 export class GameService {
   constructor(private app: FastifyInstance) {}
@@ -1027,6 +1032,33 @@ export class GameService {
     return this.prisma.game.findMany({
       orderBy: { createdAt: "desc" },
     });
+  }
+
+  async rebuildGameFromEventLog(gameId: string, rows: RebuildEventInput[]) {
+    const game = await this.prisma.game.findUnique({ where: { id: gameId } });
+    if (!game) throw this.notFound("Game not found");
+
+    const RERUN_TMP = "__rerun_tmp_";
+    const forSort = rows.map((e, i) => ({
+      ...e,
+      id: e.id ?? `${RERUN_TMP}${i}`,
+    }));
+
+    sortEventsForRerun(forSort);
+
+    const forRerun: RebuildEventInput[] = forSort.map((e) => ({
+      ...e,
+      id: e.id!.startsWith(RERUN_TMP) ? undefined : e.id,
+    }));
+
+    try {
+      await this.prisma.$transaction((tx) => rerunGameEventLog(tx, gameId, forRerun));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw this.badRequest(msg);
+    }
+
+    return this.emitState(gameId);
   }
 }
 

--- a/server/src/services/gameEventRerun.sort.test.ts
+++ b/server/src/services/gameEventRerun.sort.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { sortEventsForRerun } from "./gameEventRerun";
+
+describe("sortEventsForRerun", () => {
+  it("orders by createdAt then id", () => {
+    const arr = [
+      { id: "b", createdAt: "2020-01-01T12:00:00.000Z" },
+      { id: "a", createdAt: "2020-01-01T12:00:00.000Z" },
+    ];
+    sortEventsForRerun(arr);
+    assert.deepEqual(
+      arr.map((x) => x.id),
+      ["a", "b"]
+    );
+  });
+});

--- a/server/src/services/gameEventRerun.ts
+++ b/server/src/services/gameEventRerun.ts
@@ -1,0 +1,519 @@
+import {
+  GameEventType,
+  GameStatus,
+  TeamSide,
+  ExclusionStatus,
+} from ".prisma/client";
+import type { Prisma } from "@prisma/client";
+import { startClock, stopClock, setClockRemaining } from "../lib/clock";
+
+export type RebuildEventInput = {
+  id?: string;
+  eventType: GameEventType;
+  payload?: unknown;
+  createdAt: string;
+  source?: string;
+};
+
+export function sortEventsForRerun(events: { createdAt: string; id: string }[]) {
+  events.sort((a, b) => {
+    const ta = new Date(a.createdAt).getTime();
+    const tb = new Date(b.createdAt).getTime();
+    if (ta !== tb) return ta - tb;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+function asPayload(p: unknown): Record<string, unknown> {
+  return p != null && typeof p === "object" && !Array.isArray(p)
+    ? (p as Record<string, unknown>)
+    : {};
+}
+
+/** Rebuilds derived game state from an ordered event log and rewrites GameEvent rows. */
+export async function rerunGameEventLog(
+  tx: Prisma.TransactionClient,
+  gameId: string,
+  sortedEvents: RebuildEventInput[]
+): Promise<void> {
+  if (sortedEvents.length === 0) {
+    throw new Error("Event log cannot be empty");
+  }
+
+  const game = await tx.game.findUnique({
+    where: { id: gameId },
+    include: {
+      score: true,
+      gameClock: true,
+      shotClock: true,
+      timeoutStates: true,
+    },
+  });
+  if (!game || !game.score || !game.gameClock || !game.shotClock) {
+    throw new Error("Game not found or missing score/clocks");
+  }
+
+  const first = sortedEvents[0];
+  if (first.eventType !== GameEventType.GAME_CREATED) {
+    throw new Error("First event must be GAME_CREATED");
+  }
+
+  const createdPayload = asPayload(first.payload);
+  const initialTotalPeriods =
+    typeof createdPayload.totalPeriods === "number"
+      ? createdPayload.totalPeriods
+      : game.totalPeriods;
+
+  await tx.score.update({
+    where: { id: game.score.id },
+    data: { homeScore: 0, awayScore: 0 },
+  });
+
+  await tx.gameClock.update({
+    where: { id: game.gameClock.id },
+    data: {
+      remainingMs: game.gameClock.durationMs,
+      running: false,
+      lastStartedAt: null,
+    },
+  });
+
+  await tx.shotClock.update({
+    where: { id: game.shotClock.id },
+    data: {
+      remainingMs: game.shotClock.durationMs,
+      running: false,
+      lastStartedAt: null,
+    },
+  });
+
+  for (const ts of game.timeoutStates) {
+    await tx.teamTimeoutState.update({
+      where: { id: ts.id },
+      data: { fullTimeoutsRemaining: 2, shortTimeoutsRemaining: 1 },
+    });
+  }
+
+  await tx.playerExclusion.deleteMany({ where: { gameId } });
+
+  await tx.game.update({
+    where: { id: gameId },
+    data: {
+      currentPeriod: 1,
+      status: GameStatus.PENDING,
+      totalPeriods: initialTotalPeriods,
+      scheduledAt: null,
+    },
+  });
+
+  const exclusionIdMap = new Map<string, string>();
+  const foulStartsByCap = new Map<string, number>();
+  const capKey = (side: TeamSide, cap: string) => `${side}:${cap}`;
+
+  const outRows: {
+    id?: string;
+    eventType: GameEventType;
+    payload: Prisma.InputJsonValue;
+    createdAt: Date;
+    source: string;
+  }[] = [];
+
+  for (const ev of sortedEvents) {
+    const createdAt = new Date(ev.createdAt);
+    const source = ev.source ?? "operator";
+    let payloadOut: Prisma.InputJsonValue = (ev.payload ?? {}) as Prisma.InputJsonValue;
+
+    switch (ev.eventType) {
+      case GameEventType.GAME_CREATED:
+        break;
+
+      case GameEventType.GOAL_HOME:
+      case GameEventType.GOAL_AWAY: {
+        const p = asPayload(ev.payload);
+        const side =
+          ev.eventType === GameEventType.GOAL_HOME ? TeamSide.HOME : TeamSide.AWAY;
+        const cap = p.capNumber != null ? String(p.capNumber) : "";
+        if (cap) {
+          const player = await tx.player.findFirst({
+            where: { gameId, teamSide: side, capNumber: cap },
+          });
+          if (!player) {
+            throw new Error(
+              `GOAL: no player with cap ${cap} on ${side === TeamSide.HOME ? "HOME" : "AWAY"}`
+            );
+          }
+          const n = foulStartsByCap.get(capKey(side, cap)) ?? 0;
+          if (n >= 3) {
+            throw new Error(
+              `Player ${cap} has been rolled; cannot record another goal for them`
+            );
+          }
+        }
+        const delta = typeof p.delta === "number" ? p.delta : 1;
+        const scoreRow = await tx.score.findUnique({ where: { gameId } });
+        if (!scoreRow) throw new Error("Score row missing");
+        let nextHome = scoreRow.homeScore;
+        let nextAway = scoreRow.awayScore;
+        if (side === TeamSide.HOME) {
+          nextHome = Math.max(0, scoreRow.homeScore + delta);
+        } else {
+          nextAway = Math.max(0, scoreRow.awayScore + delta);
+        }
+        await tx.score.update({
+          where: { id: scoreRow.id },
+          data: { homeScore: nextHome, awayScore: nextAway },
+        });
+        payloadOut = {
+          ...p,
+          side,
+          delta,
+          homeScore: nextHome,
+          awayScore: nextAway,
+        } as Prisma.InputJsonValue;
+        break;
+      }
+
+      case GameEventType.GAME_CLOCK_STARTED: {
+        const g = await tx.game.findUnique({
+          where: { id: gameId },
+          include: { gameClock: true },
+        });
+        if (!g?.gameClock) throw new Error("Game clock missing");
+        if (g.currentPeriod === 1 && g.scheduledAt == null) {
+          await tx.game.update({
+            where: { id: gameId },
+            data: { scheduledAt: new Date(), status: GameStatus.IN_PROGRESS },
+          });
+        } else if (g.status === GameStatus.PENDING) {
+          await tx.game.update({
+            where: { id: gameId },
+            data: { status: GameStatus.IN_PROGRESS },
+          });
+        }
+        const clock = g.gameClock;
+        const newState = startClock({
+          durationMs: clock.durationMs,
+          remainingMs: clock.remainingMs,
+          running: clock.running,
+          lastStartedAt: clock.lastStartedAt,
+        });
+        await tx.gameClock.update({
+          where: { id: clock.id },
+          data: {
+            running: newState.running,
+            lastStartedAt: newState.lastStartedAt,
+          },
+        });
+        break;
+      }
+
+      case GameEventType.GAME_CLOCK_STOPPED: {
+        const clock = await tx.gameClock.findUnique({ where: { gameId } });
+        if (!clock) throw new Error("Game clock missing");
+        const newState = stopClock({
+          durationMs: clock.durationMs,
+          remainingMs: clock.remainingMs,
+          running: clock.running,
+          lastStartedAt: clock.lastStartedAt,
+        });
+        await tx.gameClock.update({
+          where: { id: clock.id },
+          data: {
+            running: newState.running,
+            remainingMs: newState.remainingMs,
+            lastStartedAt: newState.lastStartedAt,
+          },
+        });
+        break;
+      }
+
+      case GameEventType.GAME_CLOCK_SET: {
+        const p = asPayload(ev.payload);
+        const remainingMs =
+          typeof p.remainingMs === "number" ? p.remainingMs : 0;
+        const clock = await tx.gameClock.findUnique({ where: { gameId } });
+        if (!clock) throw new Error("Game clock missing");
+        const newState = setClockRemaining(
+          {
+            durationMs: clock.durationMs,
+            remainingMs: clock.remainingMs,
+            running: clock.running,
+            lastStartedAt: clock.lastStartedAt,
+          },
+          remainingMs
+        );
+        await tx.gameClock.update({
+          where: { id: clock.id },
+          data: {
+            remainingMs: newState.remainingMs,
+            lastStartedAt: newState.lastStartedAt,
+          },
+        });
+        break;
+      }
+
+      case GameEventType.SHOT_CLOCK_STARTED: {
+        const clock = await tx.shotClock.findUnique({ where: { gameId } });
+        if (!clock) throw new Error("Shot clock missing");
+        const newState = startClock({
+          durationMs: clock.durationMs,
+          remainingMs: clock.remainingMs,
+          running: clock.running,
+          lastStartedAt: clock.lastStartedAt,
+        });
+        await tx.shotClock.update({
+          where: { id: clock.id },
+          data: {
+            running: newState.running,
+            lastStartedAt: newState.lastStartedAt,
+          },
+        });
+        break;
+      }
+
+      case GameEventType.SHOT_CLOCK_STOPPED: {
+        const clock = await tx.shotClock.findUnique({ where: { gameId } });
+        if (!clock) throw new Error("Shot clock missing");
+        const newState = stopClock({
+          durationMs: clock.durationMs,
+          remainingMs: clock.remainingMs,
+          running: clock.running,
+          lastStartedAt: clock.lastStartedAt,
+        });
+        await tx.shotClock.update({
+          where: { id: clock.id },
+          data: {
+            running: newState.running,
+            remainingMs: newState.remainingMs,
+            lastStartedAt: newState.lastStartedAt,
+          },
+        });
+        break;
+      }
+
+      case GameEventType.SHOT_CLOCK_RESET: {
+        const clock = await tx.shotClock.findUnique({ where: { gameId } });
+        if (!clock) throw new Error("Shot clock missing");
+        await tx.shotClock.update({
+          where: { id: clock.id },
+          data: {
+            remainingMs: clock.durationMs,
+            running: false,
+            lastStartedAt: null,
+          },
+        });
+        payloadOut = { durationMs: clock.durationMs } as Prisma.InputJsonValue;
+        break;
+      }
+
+      case GameEventType.SHOT_CLOCK_SET: {
+        const p = asPayload(ev.payload);
+        const remainingMs =
+          typeof p.remainingMs === "number" ? p.remainingMs : 0;
+        const clock = await tx.shotClock.findUnique({ where: { gameId } });
+        if (!clock) throw new Error("Shot clock missing");
+        const newState = setClockRemaining(
+          {
+            durationMs: clock.durationMs,
+            remainingMs: clock.remainingMs,
+            running: clock.running,
+            lastStartedAt: clock.lastStartedAt,
+          },
+          remainingMs
+        );
+        await tx.shotClock.update({
+          where: { id: clock.id },
+          data: {
+            remainingMs: newState.remainingMs,
+            lastStartedAt: newState.lastStartedAt,
+          },
+        });
+        break;
+      }
+
+      case GameEventType.PERIOD_ADVANCED: {
+        const p = asPayload(ev.payload);
+        const from = typeof p.from === "number" ? p.from : 1;
+        const to = typeof p.to === "number" ? p.to : from + 1;
+        const g = await tx.game.findUnique({ where: { id: gameId } });
+        if (!g) throw new Error("Game missing");
+
+        if (from === 4 && to === 5) {
+          await tx.game.update({
+            where: { id: gameId },
+            data: { currentPeriod: 5, totalPeriods: 5 },
+          });
+        } else {
+          const data: { currentPeriod: number; status?: GameStatus } = {
+            currentPeriod: to,
+          };
+          if (g.totalPeriods === 4 && to === 4) {
+            data.status = GameStatus.FINAL;
+          }
+          await tx.game.update({
+            where: { id: gameId },
+            data,
+          });
+        }
+        const scoreRow = await tx.score.findUnique({ where: { gameId } });
+        payloadOut = {
+          ...p,
+          from,
+          to,
+          ...(scoreRow
+            ? { homeScore: scoreRow.homeScore, awayScore: scoreRow.awayScore }
+            : {}),
+        } as Prisma.InputJsonValue;
+        break;
+      }
+
+      case GameEventType.EXCLUSION_STARTED: {
+        const p = asPayload(ev.payload);
+        const playerId = typeof p.playerId === "string" ? p.playerId : "";
+        const player = await tx.player.findFirst({
+          where: playerId
+            ? { id: playerId, gameId }
+            : {
+                gameId,
+                teamSide: (p.teamSide as TeamSide) ?? TeamSide.HOME,
+                capNumber: String(p.capNumber ?? ""),
+              },
+        });
+        if (!player) {
+          throw new Error("EXCLUSION_STARTED: player not found");
+        }
+        const g = await tx.game.findUnique({
+          where: { id: gameId },
+          select: { currentPeriod: true },
+        });
+        const currentPeriod = g?.currentPeriod ?? 1;
+        const durationMs =
+          typeof p.durationMs === "number" && p.durationMs > 0
+            ? p.durationMs
+            : 20_000;
+
+        const exclusion = await tx.playerExclusion.create({
+          data: {
+            gameId,
+            playerId: player.id,
+            teamSide: player.teamSide,
+            durationMs,
+            remainingMs: durationMs,
+            running: true,
+            status: ExclusionStatus.ACTIVE,
+          },
+        });
+
+        const oldExId =
+          typeof p.exclusionId === "string" ? p.exclusionId : undefined;
+        if (oldExId) exclusionIdMap.set(oldExId, exclusion.id);
+
+        const key = capKey(player.teamSide, player.capNumber);
+        foulStartsByCap.set(key, (foulStartsByCap.get(key) ?? 0) + 1);
+
+        payloadOut = {
+          ...p,
+          exclusionId: exclusion.id,
+          playerId: player.id,
+          teamSide: player.teamSide,
+          capNumber: player.capNumber,
+          durationMs,
+          period: currentPeriod,
+          isPenalty: p.isPenalty === true,
+          ...(typeof p.timeSeconds === "number"
+            ? { timeSeconds: p.timeSeconds }
+            : {}),
+        } as Prisma.InputJsonValue;
+        break;
+      }
+
+      case GameEventType.EXCLUSION_CLEARED: {
+        const p = asPayload(ev.payload);
+        if (p.exclusionId != null) {
+          const rawId = String(p.exclusionId);
+          const mapped = exclusionIdMap.get(rawId) ?? rawId;
+          const exclusion = await tx.playerExclusion.findFirst({
+            where: { id: mapped, gameId },
+          });
+          if (exclusion) {
+            await tx.playerExclusion.update({
+              where: { id: exclusion.id },
+              data: {
+                remainingMs: 0,
+                running: false,
+                status: ExclusionStatus.ROLLED,
+                endedAt: new Date(),
+              },
+            });
+          }
+          payloadOut = { exclusionId: mapped } as Prisma.InputJsonValue;
+        } else {
+          payloadOut = (ev.payload ?? {}) as Prisma.InputJsonValue;
+        }
+        break;
+      }
+
+      case GameEventType.TIMEOUT_USED: {
+        const p = asPayload(ev.payload);
+        const teamSide = (p.teamSide ?? p.side) as TeamSide | undefined;
+        if (!teamSide || (teamSide !== TeamSide.HOME && teamSide !== TeamSide.AWAY)) {
+          throw new Error("TIMEOUT_USED: missing teamSide");
+        }
+        const type = p.type === "short" ? "short" : "full";
+        const timeoutState = await tx.teamTimeoutState.findUnique({
+          where: {
+            gameId_teamSide: { gameId, teamSide },
+          },
+        });
+        if (!timeoutState) throw new Error("Timeout state missing");
+        const field =
+          type === "full" ? "fullTimeoutsRemaining" : "shortTimeoutsRemaining";
+        const remaining = timeoutState[field];
+        if (remaining <= 0) {
+          throw new Error("No timeouts remaining for team during rerun");
+        }
+        await tx.teamTimeoutState.update({
+          where: { id: timeoutState.id },
+          data: { [field]: remaining - 1 },
+        });
+        payloadOut = {
+          teamSide,
+          type,
+          ...(typeof p.timeSeconds === "number"
+            ? { timeSeconds: p.timeSeconds }
+            : {}),
+        } as Prisma.InputJsonValue;
+        break;
+      }
+
+      case GameEventType.HORN_TRIGGERED:
+        break;
+
+      default:
+        throw new Error(`Unsupported event type for rerun: ${ev.eventType}`);
+    }
+
+    outRows.push({
+      id: ev.id,
+      eventType: ev.eventType,
+      payload: payloadOut,
+      createdAt,
+      source,
+    });
+  }
+
+  await tx.gameEvent.deleteMany({ where: { gameId } });
+
+  for (const row of outRows) {
+    await tx.gameEvent.create({
+      data: {
+        ...(row.id ? { id: row.id } : {}),
+        gameId,
+        eventType: row.eventType,
+        payload: row.payload,
+        source: row.source,
+        createdAt: row.createdAt,
+      },
+    });
+  }
+}

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,6 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
     "rootDir": "src",
+    "noEmit": true,
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -537,6 +537,199 @@
   text-align: center;
 }
 
+.game-sheet-progress-edit-modal {
+  max-width: min(94vw, 42rem);
+  width: 100%;
+  max-height: min(92vh, 52rem);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding-top: 1.1rem;
+  padding-bottom: 1.1rem;
+}
+
+.game-sheet-progress-edit-modal > .game-sheet-timeouts-header {
+  flex-shrink: 0;
+}
+
+.game-sheet-progress-edit-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 0.2rem;
+  margin-right: -0.2rem;
+}
+
+.game-sheet-progress-edit-sticky-footer {
+  flex-shrink: 0;
+  margin-top: 0.65rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.game-sheet-progress-edit-sticky-footer .game-sheet-progress-rerun-note {
+  margin: 0.5rem 0 0;
+}
+
+.game-sheet-progress-edit-meta {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.game-sheet-progress-edit-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem 1.25rem;
+  margin-bottom: 1rem;
+  align-items: start;
+}
+
+/* Beat global `.form` (flex + max-width) on progress modal field groups */
+.game-sheet-progress-edit-modal .form.game-sheet-progress-edit-fields {
+  display: grid;
+  max-width: none;
+  gap: 0.65rem 1.25rem;
+}
+
+.game-sheet-progress-edit-fields label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.game-sheet-progress-edit-modal .game-sheet-progress-field-span,
+.game-sheet-progress-edit-modal .game-sheet-progress-edit-fields > .game-sheet-progress-hint,
+.game-sheet-progress-edit-modal .game-sheet-progress-edit-fields > .game-sheet-progress-checkbox,
+.game-sheet-progress-edit-modal .game-sheet-progress-edit-fields > .game-sheet-progress-command-preview {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 520px) {
+  .game-sheet-progress-edit-modal .game-sheet-progress-edit-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .game-sheet-progress-edit-modal .game-sheet-progress-field-span,
+  .game-sheet-progress-edit-modal .game-sheet-progress-edit-fields > .game-sheet-progress-hint,
+  .game-sheet-progress-edit-modal .game-sheet-progress-edit-fields > .game-sheet-progress-checkbox,
+  .game-sheet-progress-edit-modal .game-sheet-progress-edit-fields > .game-sheet-progress-command-preview {
+    grid-column: 1;
+  }
+}
+
+.game-sheet-progress-command-preview {
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0.55rem;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.game-sheet-progress-command-preview-label {
+  display: block;
+  font-weight: 600;
+  opacity: 0.92;
+}
+
+.game-sheet-progress-command-preview-code {
+  display: block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.95em;
+  padding: 0.25rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.25);
+  word-break: break-all;
+}
+
+.game-sheet-progress-command-preview-note {
+  display: block;
+  font-size: 0.78rem;
+  opacity: 0.75;
+  line-height: 1.35;
+}
+
+@media (prefers-color-scheme: light) {
+  .game-sheet-progress-command-preview {
+    background: rgba(0, 0, 0, 0.05);
+  }
+
+  .game-sheet-progress-command-preview-code {
+    background: rgba(0, 0, 0, 0.06);
+  }
+}
+
+.game-sheet-progress-hint,
+.game-sheet-progress-readonly {
+  font-size: 0.85rem;
+  opacity: 0.88;
+  margin: 0 0 0.75rem;
+  line-height: 1.4;
+}
+
+.game-sheet-progress-checkbox {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 0.5rem !important;
+}
+
+.game-sheet-progress-insert-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.game-sheet-progress-insert-panel {
+  padding: 0.75rem 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  margin-bottom: 0.5rem;
+}
+
+.game-sheet-progress-insert-panel .game-sheet-modal-actions {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.game-sheet-progress-insert-panel h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+}
+
+.game-sheet-progress-edit-footer {
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 0.5rem;
+}
+
+.game-sheet-progress-edit-footer .game-sheet-progress-update-btn {
+  min-width: 12.5rem;
+  text-align: center;
+}
+
+.game-sheet-progress-rerun-note {
+  margin: 0.75rem 0 0;
+  font-size: 0.78rem;
+  opacity: 0.75;
+  line-height: 1.35;
+}
+
+@media (prefers-color-scheme: light) {
+  .game-sheet-progress-insert-panel {
+    border-top-color: rgba(0, 0, 0, 0.1);
+  }
+
+  .game-sheet-progress-edit-sticky-footer {
+    border-top-color: rgba(0, 0, 0, 0.1);
+  }
+}
+
 .game-sheet-progress-table-wrapper {
   flex: 1;
   min-height: 0;
@@ -791,6 +984,14 @@
   align-items: center;
   justify-content: center;
   padding: 1rem;
+}
+
+/* Tall progress editor: start below top bar, allow overlay scroll if needed */
+.game-sheet-modal-overlay--progress-edit {
+  align-items: flex-start;
+  justify-content: center;
+  padding: 1.25rem 1rem 2rem;
+  overflow-y: auto;
 }
 
 .game-sheet-modal {
@@ -1178,6 +1379,33 @@
 
 .btn.primary:hover {
   background: #535bf2;
+}
+
+.btn.primary:disabled,
+.btn.primary[disabled] {
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.42);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.btn.primary:disabled:hover,
+.btn.primary[disabled]:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+@media (prefers-color-scheme: light) {
+  .btn.primary:disabled,
+  .btn.primary[disabled] {
+    background: #e8e8e8;
+    color: #888;
+    border-color: #d0d0d0;
+  }
+
+  .btn.primary:disabled:hover,
+  .btn.primary[disabled]:hover {
+    background: #e8e8e8;
+  }
 }
 
 .btn.secondary {

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -104,6 +104,7 @@ export interface GameAggregate {
     eventType: string;
     payload: any;
     createdAt: string;
+    source?: string;
   }[];
 }
 
@@ -171,6 +172,22 @@ export const api = {
       }
     ) =>
       request<GameAggregate>(`/games/${id}/score-command`, {
+        method: "POST",
+        json: body,
+      }),
+    rebuildEventLog: (
+      id: string,
+      body: {
+        events: {
+          id?: string;
+          eventType: string;
+          payload?: unknown;
+          createdAt: string;
+          source?: string;
+        }[];
+      }
+    ) =>
+      request<GameAggregate>(`/games/${id}/event-log/rebuild`, {
         method: "POST",
         json: body,
       }),

--- a/ui/src/pages/AddGame.tsx
+++ b/ui/src/pages/AddGame.tsx
@@ -76,7 +76,9 @@ export function AddGame() {
       </header>
 
       <form onSubmit={handleSubmit} className="form">
-        {error && <p className="error">{formatApiErrorMessage(error)}</p>}
+        {error != null ? (
+          <p className="error">{formatApiErrorMessage(error)}</p>
+        ) : null}
         <label>
           Home team (dark caps)
           <input

--- a/ui/src/pages/EditGame.tsx
+++ b/ui/src/pages/EditGame.tsx
@@ -77,7 +77,9 @@ export function EditGame() {
       </header>
 
       <form onSubmit={handleSubmit} className="form">
-        {error && <p className="error">{formatApiErrorMessage(error)}</p>}
+        {error != null ? (
+          <p className="error">{formatApiErrorMessage(error)}</p>
+        ) : null}
         <label>
           Home team (dark caps)
           <input

--- a/ui/src/pages/EditGameDay.tsx
+++ b/ui/src/pages/EditGameDay.tsx
@@ -57,7 +57,9 @@ export function EditGameDay() {
       </header>
 
       <form onSubmit={handleSubmit} className="form">
-        {error && <p className="error">{formatApiErrorMessage(error)}</p>}
+        {error != null ? (
+          <p className="error">{formatApiErrorMessage(error)}</p>
+        ) : null}
         <label>
           Date
           <input

--- a/ui/src/pages/GameRoster.tsx
+++ b/ui/src/pages/GameRoster.tsx
@@ -464,7 +464,9 @@ export function GameRoster() {
         </table>
       </div>
 
-      {error && <p className="error">{formatApiErrorMessage(error)}</p>}
+      {error != null ? (
+        <p className="error">{formatApiErrorMessage(error)}</p>
+      ) : null}
 
       <div className="form-actions">
         <button

--- a/ui/src/pages/GameSheet.tsx
+++ b/ui/src/pages/GameSheet.tsx
@@ -85,6 +85,25 @@ export function GameSheet() {
   const [eqOvertimeModalOpen, setEqOvertimeModalOpen] = useState(false);
   const [eqEditEntriesModalOpen, setEqEditEntriesModalOpen] = useState(false);
   const pendingEditModalAfterEnd = useRef(false);
+  const [progressEditOpen, setProgressEditOpen] = useState(false);
+  const [progressEditEvents, setProgressEditEvents] = useState<GameAggregate["events"] | null>(null);
+  const [progressEditSelectedId, setProgressEditSelectedId] = useState<string | null>(null);
+  const [progressEditError, setProgressEditError] = useState<string | null>(null);
+  const [progressEditBusy, setProgressEditBusy] = useState(false);
+  const [progressInsertMode, setProgressInsertMode] = useState<null | "before" | "after">(null);
+  const [insertKind, setInsertKind] = useState<
+    "GOAL" | "EXCLUSION" | "PENALTY" | "TIMEOUT" | "TIMEOUT_30"
+  >("GOAL");
+  const [insertSide, setInsertSide] = useState<TeamSide>("HOME");
+  const [insertCap, setInsertCap] = useState("");
+  const [insertTimeSec, setInsertTimeSec] = useState("");
+  const [gfSide, setGfSide] = useState<TeamSide>("HOME");
+  const [gfCap, setGfCap] = useState("");
+  const [gfTime, setGfTime] = useState("");
+  const [exPenalty, setExPenalty] = useState(false);
+  const [exTime, setExTime] = useState("");
+  const [toSide, setToSide] = useState<TeamSide>("HOME");
+  const [toShort, setToShort] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -95,6 +114,51 @@ export function GameSheet() {
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [commandHelpOpen]);
+
+  useEffect(() => {
+    if (!progressEditOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setProgressEditOpen(false);
+        setProgressInsertMode(null);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [progressEditOpen]);
+
+  const progressSelected =
+    progressEditEvents?.find((e) => e.id === progressEditSelectedId) ?? null;
+
+  useEffect(() => {
+    if (!progressEditOpen || !progressSelected) return;
+    const p = progressSelected.payload as Record<string, unknown>;
+    if (
+      progressSelected.eventType === "GOAL_HOME" ||
+      progressSelected.eventType === "GOAL_AWAY"
+    ) {
+      setGfSide(progressSelected.eventType === "GOAL_HOME" ? "HOME" : "AWAY");
+      setGfCap(String(p.capNumber ?? ""));
+      setGfTime(
+        typeof p.timeSeconds === "number"
+          ? formatGameClockTimeForInput(p.timeSeconds)
+          : ""
+      );
+    }
+    if (progressSelected.eventType === "EXCLUSION_STARTED") {
+      setExPenalty(p.isPenalty === true);
+      setExTime(
+        typeof p.timeSeconds === "number"
+          ? formatGameClockTimeForInput(p.timeSeconds)
+          : ""
+      );
+    }
+    if (progressSelected.eventType === "TIMEOUT_USED") {
+      const side = (p.teamSide ?? p.side) as TeamSide;
+      if (side === "HOME" || side === "AWAY") setToSide(side);
+      setToShort(p.type === "short");
+    }
+  }, [progressEditOpen, progressEditSelectedId, progressSelected?.id, progressSelected?.eventType]);
 
   useEffect(() => {
     if (!gameDayId || !gameId) return;
@@ -425,8 +489,236 @@ export function GameSheet() {
       isQuarterStart,
       isQuarterEnd,
       foulCount,
+      editable: ev.eventType !== "GAME_CREATED",
     };
   });
+
+  const openProgressEditForRow = (rowId: string) => {
+    const full = [...(aggregate.events ?? [])];
+    sortGameEventsAsc(full);
+    setProgressEditEvents(full);
+    setProgressEditSelectedId(rowId);
+    setProgressEditError(null);
+    setProgressInsertMode(null);
+    setProgressEditOpen(true);
+  };
+
+  const applyInsertEntry = () => {
+    if (!progressEditEvents || !progressEditSelectedId || !gameId || !progressInsertMode) return;
+    let built: { eventType: string; payload: Record<string, unknown> };
+    let ts: { timeSeconds?: number } = {};
+    if (insertTimeSec.trim() !== "") {
+      const parsed = parseOptionalGameClockTime(insertTimeSec);
+      if (!parsed.ok) {
+        setProgressEditError(parsed.error);
+        return;
+      }
+      if (parsed.seconds !== undefined) ts = { timeSeconds: parsed.seconds };
+    }
+    try {
+      if (insertKind === "GOAL") {
+        const et = insertSide === "HOME" ? "GOAL_HOME" : "GOAL_AWAY";
+        if (!insertCap.trim()) throw new Error("Cap # is required for a goal.");
+        built = {
+          eventType: et,
+          payload: {
+            side: insertSide,
+            capNumber: insertCap.trim(),
+            delta: 1,
+            ...ts,
+          },
+        };
+      } else if (insertKind === "EXCLUSION" || insertKind === "PENALTY") {
+        const pl = aggregate.players.find(
+          (p) => p.teamSide === insertSide && p.capNumber === insertCap.trim()
+        );
+        if (!pl) throw new Error("No roster player matches that team and cap.");
+        built = {
+          eventType: "EXCLUSION_STARTED",
+          payload: {
+            playerId: pl.id,
+            teamSide: insertSide,
+            capNumber: pl.capNumber,
+            durationMs: 20000,
+            isPenalty: insertKind === "PENALTY",
+            ...ts,
+          },
+        };
+      } else if (insertKind === "TIMEOUT") {
+        built = {
+          eventType: "TIMEOUT_USED",
+          payload: { teamSide: insertSide, type: "full", ...ts },
+        };
+      } else {
+        built = {
+          eventType: "TIMEOUT_USED",
+          payload: { teamSide: insertSide, type: "short", ...ts },
+        };
+      }
+    } catch (e) {
+      setProgressEditError(e instanceof Error ? e.message : String(e));
+      return;
+    }
+    const anchorId = progressEditSelectedId;
+    const idx = progressEditEvents.findIndex((e) => e.id === anchorId);
+    if (idx === -1) return;
+    const insertIdx = progressInsertMode === "before" ? idx : idx + 1;
+    const prevEv = insertIdx > 0 ? progressEditEvents[insertIdx - 1] : null;
+    const nextEv =
+      insertIdx < progressEditEvents.length ? progressEditEvents[insertIdx] : null;
+    let createdAt: string;
+    if (prevEv && nextEv) {
+      const ta = new Date(prevEv.createdAt).getTime();
+      const tb = new Date(nextEv.createdAt).getTime();
+      if (tb > ta) {
+        createdAt = new Date(ta + Math.floor((tb - ta) / 2)).toISOString();
+      } else {
+        createdAt = new Date(ta + 1).toISOString();
+      }
+    } else if (prevEv) {
+      createdAt = new Date(new Date(prevEv.createdAt).getTime() + 500).toISOString();
+    } else if (nextEv) {
+      createdAt = new Date(new Date(nextEv.createdAt).getTime() - 500).toISOString();
+    } else {
+      createdAt = new Date().toISOString();
+    }
+    const newRow: GameAggregate["events"][number] = {
+      id: `__insert_${Date.now()}`,
+      gameId,
+      eventType: built.eventType,
+      payload: built.payload,
+      createdAt,
+      source: "operator",
+    };
+    const copy = [...progressEditEvents];
+    copy.splice(insertIdx, 0, newRow);
+    setProgressEditEvents(copy);
+    setProgressInsertMode(null);
+    setProgressEditError(null);
+  };
+
+  const deleteProgressEntry = () => {
+    if (!progressEditEvents || !progressEditSelectedId) return;
+    const target = progressEditEvents.find((e) => e.id === progressEditSelectedId);
+    if (target?.eventType === "GAME_CREATED") {
+      setProgressEditError("Cannot delete the Game created row.");
+      return;
+    }
+    const delIdx = progressEditEvents.findIndex((e) => e.id === progressEditSelectedId);
+    const filtered = progressEditEvents.filter((e) => e.id !== progressEditSelectedId);
+    if (filtered.length === 0 || filtered[0]?.eventType !== "GAME_CREATED") {
+      setProgressEditError("Timeline must keep Game created as the first row.");
+      return;
+    }
+    if (
+      !confirm(
+        "Delete this entry from the timeline? Click Update & rerun to save to the server."
+      )
+    ) {
+      return;
+    }
+    const nextSel =
+      filtered[Math.max(0, delIdx - 1)]?.id ?? filtered[0]?.id ?? null;
+    setProgressEditEvents(filtered);
+    setProgressEditSelectedId(nextSel);
+  };
+
+  const submitProgressRebuild = async () => {
+    if (!gameId || !progressEditEvents?.length) return;
+    let list = [...progressEditEvents];
+    const sel = list.find((e) => e.id === progressEditSelectedId);
+    if (sel) {
+      if (sel.eventType === "GOAL_HOME" || sel.eventType === "GOAL_AWAY") {
+        if (!gfCap.trim()) {
+          setProgressEditError("Cap # is required for a goal.");
+          return;
+        }
+        const newType = gfSide === "HOME" ? "GOAL_HOME" : "GOAL_AWAY";
+        const prev = sel.payload as Record<string, unknown>;
+        const gfParsed = parseOptionalGameClockTime(gfTime);
+        if (!gfParsed.ok) {
+          setProgressEditError(gfParsed.error);
+          return;
+        }
+        list = list.map((e) =>
+          e.id !== sel.id
+            ? e
+            : (() => {
+                const nextPayload: Record<string, unknown> = {
+                  ...prev,
+                  side: gfSide,
+                  capNumber: gfCap.trim(),
+                  delta: typeof prev.delta === "number" ? prev.delta : 1,
+                };
+                if (gfParsed.seconds !== undefined) {
+                  nextPayload.timeSeconds = gfParsed.seconds;
+                } else {
+                  delete nextPayload.timeSeconds;
+                }
+                return { ...e, eventType: newType, payload: nextPayload };
+              })()
+        );
+      } else if (sel.eventType === "EXCLUSION_STARTED") {
+        const prev = sel.payload as Record<string, unknown>;
+        const exParsed = parseOptionalGameClockTime(exTime);
+        if (!exParsed.ok) {
+          setProgressEditError(exParsed.error);
+          return;
+        }
+        list = list.map((e) =>
+          e.id !== sel.id
+            ? e
+            : (() => {
+                const nextPayload: Record<string, unknown> = {
+                  ...prev,
+                  isPenalty: exPenalty,
+                };
+                if (exParsed.seconds !== undefined) {
+                  nextPayload.timeSeconds = exParsed.seconds;
+                } else {
+                  delete nextPayload.timeSeconds;
+                }
+                return { ...e, payload: nextPayload };
+              })()
+        );
+      } else if (sel.eventType === "TIMEOUT_USED") {
+        const prev = sel.payload as Record<string, unknown>;
+        list = list.map((e) =>
+          e.id !== sel.id
+            ? e
+            : {
+                ...e,
+                payload: {
+                  ...prev,
+                  teamSide: toSide,
+                  type: toShort ? "short" : "full",
+                },
+              }
+        );
+      }
+    }
+    setProgressEditBusy(true);
+    setProgressEditError(null);
+    try {
+      const next = await api.games.rebuildEventLog(gameId, {
+        events: list.map((e) => ({
+          id: e.id.startsWith("__insert_") ? undefined : e.id,
+          eventType: e.eventType,
+          payload: e.payload,
+          createdAt: e.createdAt,
+          source: e.source ?? "operator",
+        })),
+      });
+      setAggregate(next);
+      setProgressEditOpen(false);
+      setProgressEditEvents(null);
+      setProgressEditSelectedId(null);
+    } catch (err) {
+      setProgressEditError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setProgressEditBusy(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -770,6 +1062,390 @@ export function GameSheet() {
             </div>
           )}
 
+          {progressEditOpen && progressEditEvents && progressEditSelectedId && (
+            <div
+              className="game-sheet-modal-overlay game-sheet-modal-overlay--progress-edit"
+              role="dialog"
+              aria-labelledby="progress-edit-title"
+              onClick={() => {
+                setProgressEditOpen(false);
+                setProgressInsertMode(null);
+              }}
+            >
+              <div
+                className="game-sheet-modal game-sheet-progress-edit-modal"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="game-sheet-timeouts-header">
+                  <h2 id="progress-edit-title">Edit progress entry</h2>
+                  <button
+                    type="button"
+                    className="scoring-command-help-close"
+                    onClick={() => {
+                      setProgressEditOpen(false);
+                      setProgressInsertMode(null);
+                    }}
+                    aria-label="Close"
+                  >
+                    ×
+                  </button>
+                </div>
+                {(() => {
+                  const sel =
+                    progressEditEvents.find((e) => e.id === progressEditSelectedId) ??
+                    null;
+                  if (!sel) {
+                    return (
+                      <>
+                        {progressEditError && (
+                          <p className="error">{progressEditError}</p>
+                        )}
+                        <p>No row selected.</p>
+                      </>
+                    );
+                  }
+                  return (
+                    <>
+                      <div className="game-sheet-progress-edit-scroll">
+                        {progressEditError && (
+                          <p className="error">{progressEditError}</p>
+                        )}
+                        <p className="game-sheet-progress-edit-meta">
+                        <strong>{sel.eventType.replace(/_/g, " ")}</strong>
+                        {" · "}
+                        {new Date(sel.createdAt).toLocaleString()}
+                      </p>
+
+                      {(sel.eventType === "GOAL_HOME" ||
+                        sel.eventType === "GOAL_AWAY") && (
+                        <div className="form game-sheet-progress-edit-fields">
+                          <label>
+                            Team
+                            <select
+                              value={gfSide}
+                              onChange={(e) =>
+                                setGfSide(e.target.value as TeamSide)
+                              }
+                            >
+                              <option value="HOME">Dark (home)</option>
+                              <option value="AWAY">Light (away)</option>
+                            </select>
+                          </label>
+                          <label>
+                            Cap #
+                            <input
+                              value={gfCap}
+                              onChange={(e) => setGfCap(e.target.value)}
+                            />
+                          </label>
+                          <label className="game-sheet-progress-field-span">
+                            Game clock in period (optional, same as scoring: 6.50 or 6:50)
+                            <input
+                              type="text"
+                              inputMode="decimal"
+                              placeholder="e.g. 6.50 or 6:07"
+                              value={gfTime}
+                              onChange={(e) => setGfTime(e.target.value)}
+                            />
+                          </label>
+                          {(() => {
+                            const prev = buildGoalCommandPreview(gfSide, gfCap, gfTime);
+                            return (
+                              <ScoringCommandPreviewBlock
+                                command={prev.command}
+                                note={prev.note}
+                              />
+                            );
+                          })()}
+                        </div>
+                      )}
+
+                      {sel.eventType === "EXCLUSION_STARTED" && (
+                        <div className="form game-sheet-progress-edit-fields">
+                          <p className="game-sheet-progress-hint">
+                            Team and cap are tied to the stored player. To change them,
+                            delete this row and insert a new exclusion.
+                          </p>
+                          <label className="game-sheet-progress-checkbox">
+                            <input
+                              type="checkbox"
+                              checked={exPenalty}
+                              onChange={(e) => setExPenalty(e.target.checked)}
+                            />
+                            Penalty (vs exclusion)
+                          </label>
+                          <label className="game-sheet-progress-field-span">
+                            Game clock in period (optional, same as scoring: 6.50 or 6:50)
+                            <input
+                              type="text"
+                              inputMode="decimal"
+                              placeholder="e.g. 6.50 or 6:07"
+                              value={exTime}
+                              onChange={(e) => setExTime(e.target.value)}
+                            />
+                          </label>
+                          {(() => {
+                            const pl = sel.payload as Record<string, unknown>;
+                            const rawSide = pl.teamSide ?? pl.side;
+                            const teamSide: TeamSide =
+                              rawSide === "HOME" || rawSide === "AWAY"
+                                ? rawSide
+                                : "HOME";
+                            const prev = buildExclusionCommandPreview(
+                              teamSide,
+                              String(pl.capNumber ?? ""),
+                              exTime,
+                              exPenalty
+                            );
+                            return (
+                              <ScoringCommandPreviewBlock
+                                command={prev.command}
+                                note={prev.note}
+                              />
+                            );
+                          })()}
+                        </div>
+                      )}
+
+                      {sel.eventType === "TIMEOUT_USED" && (
+                        <div className="form game-sheet-progress-edit-fields">
+                          <label>
+                            Team
+                            <select
+                              value={toSide}
+                              onChange={(e) =>
+                                setToSide(e.target.value as TeamSide)
+                              }
+                            >
+                              <option value="HOME">Dark</option>
+                              <option value="AWAY">Light</option>
+                            </select>
+                          </label>
+                          <label className="game-sheet-progress-checkbox">
+                            <input
+                              type="checkbox"
+                              checked={toShort}
+                              onChange={(e) => setToShort(e.target.checked)}
+                            />
+                            30-second timeout
+                          </label>
+                          {(() => {
+                            const pl = sel.payload as Record<string, unknown>;
+                            const ts =
+                              typeof pl.timeSeconds === "number"
+                                ? pl.timeSeconds
+                                : undefined;
+                            const prev = buildTimeoutCommandPreview(
+                              toSide,
+                              toShort,
+                              ts
+                            );
+                            return (
+                              <ScoringCommandPreviewBlock
+                                command={prev.command}
+                                note={prev.note}
+                              />
+                            );
+                          })()}
+                        </div>
+                      )}
+
+                      {![
+                        "GOAL_HOME",
+                        "GOAL_AWAY",
+                        "EXCLUSION_STARTED",
+                        "TIMEOUT_USED",
+                      ].includes(sel.eventType) && (
+                        <p className="game-sheet-progress-readonly">
+                          No field editor for this entry type. You can delete it or insert a
+                          goal, exclusion, penalty, or timeout before/after. Quarter and clock
+                          rows should stay consistent with the rest of the log.
+                        </p>
+                      )}
+
+                      <div className="game-sheet-progress-insert-toolbar">
+                        <button
+                          type="button"
+                          className="btn secondary btn-compact"
+                          onClick={() => setProgressInsertMode("before")}
+                          disabled={!!progressInsertMode}
+                        >
+                          Insert before
+                        </button>
+                        <button
+                          type="button"
+                          className="btn secondary btn-compact"
+                          onClick={() => setProgressInsertMode("after")}
+                          disabled={!!progressInsertMode}
+                        >
+                          Insert after
+                        </button>
+                      </div>
+
+                      {progressInsertMode && (
+                        <div className="game-sheet-progress-insert-panel">
+                          <h3>
+                            New entry (
+                            {progressInsertMode === "before" ? "before" : "after"}{" "}
+                            selected row)
+                          </h3>
+                          <p className="game-sheet-progress-hint">
+                            Adds one log row. Quarter starts, clock stops, etc. still use the
+                            scoring command field. Click <strong>Add to timeline</strong> when
+                            ready—<strong>Update &amp; rerun</strong> stays off until then so you
+                            don&apos;t save without the new row.
+                          </p>
+                          <div className="form game-sheet-progress-edit-fields">
+                            <label>
+                              Type
+                              <select
+                                value={insertKind}
+                                onChange={(e) =>
+                                  setInsertKind(
+                                    e.target.value as
+                                      | "GOAL"
+                                      | "EXCLUSION"
+                                      | "PENALTY"
+                                      | "TIMEOUT"
+                                      | "TIMEOUT_30"
+                                  )
+                                }
+                              >
+                                <option value="GOAL">Goal</option>
+                                <option value="EXCLUSION">Exclusion</option>
+                                <option value="PENALTY">Penalty</option>
+                                <option value="TIMEOUT">Timeout (full)</option>
+                                <option value="TIMEOUT_30">Timeout (30s)</option>
+                              </select>
+                            </label>
+                            {(insertKind === "GOAL" ||
+                              insertKind === "EXCLUSION" ||
+                              insertKind === "PENALTY" ||
+                              insertKind === "TIMEOUT" ||
+                              insertKind === "TIMEOUT_30") && (
+                              <label>
+                                Team
+                                <select
+                                  value={insertSide}
+                                  onChange={(e) =>
+                                    setInsertSide(e.target.value as TeamSide)
+                                  }
+                                >
+                                  <option value="HOME">Dark</option>
+                                  <option value="AWAY">Light</option>
+                                </select>
+                              </label>
+                            )}
+                            {(insertKind === "GOAL" ||
+                              insertKind === "EXCLUSION" ||
+                              insertKind === "PENALTY") && (
+                              <label>
+                                Cap #
+                                <input
+                                  value={insertCap}
+                                  onChange={(e) => setInsertCap(e.target.value)}
+                                />
+                              </label>
+                            )}
+                            <label className="game-sheet-progress-field-span">
+                              Game clock in period (optional, same as scoring: 6.50 or 6:50)
+                              <input
+                                type="text"
+                                inputMode="decimal"
+                                placeholder="e.g. 6.50 or 6:07"
+                                value={insertTimeSec}
+                                onChange={(e) => setInsertTimeSec(e.target.value)}
+                              />
+                            </label>
+                            {(() => {
+                              const prev = buildInsertCommandPreview(
+                                insertKind,
+                                insertSide,
+                                insertCap,
+                                insertTimeSec
+                              );
+                              return (
+                                <ScoringCommandPreviewBlock
+                                  command={prev.command}
+                                  note={prev.note}
+                                />
+                              );
+                            })()}
+                          </div>
+                          <div className="game-sheet-modal-actions">
+                            <button
+                              type="button"
+                              className="btn"
+                              onClick={() => setProgressInsertMode(null)}
+                            >
+                              Cancel insert
+                            </button>
+                            <button
+                              type="button"
+                              className="btn primary"
+                              onClick={applyInsertEntry}
+                            >
+                              Add to timeline
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                      </div>
+
+                      <div className="game-sheet-progress-edit-sticky-footer">
+                        <div className="game-sheet-modal-actions game-sheet-progress-edit-footer">
+                          <button
+                            type="button"
+                            className="btn"
+                            onClick={deleteProgressEntry}
+                            disabled={sel.eventType === "GAME_CREATED"}
+                          >
+                            Delete entry
+                          </button>
+                          <span style={{ flex: 1 }} />
+                          <button
+                            type="button"
+                            className="btn"
+                            onClick={() => {
+                              setProgressEditOpen(false);
+                              setProgressInsertMode(null);
+                            }}
+                          >
+                            Close
+                          </button>
+                          <button
+                            type="button"
+                            className="btn primary game-sheet-progress-update-btn"
+                            onClick={() => void submitProgressRebuild()}
+                            disabled={
+                              progressEditBusy || progressInsertMode != null
+                            }
+                            title={
+                              progressInsertMode
+                                ? "Click Add to timeline first, then this button saves to the server."
+                                : undefined
+                            }
+                          >
+                            {progressEditBusy
+                              ? "Working…"
+                              : progressInsertMode
+                                ? "Add to timeline first…"
+                                : "Update & rerun"}
+                          </button>
+                        </div>
+                        <p className="game-sheet-progress-rerun-note">
+                          {progressInsertMode
+                            ? "Add to timeline adds the row to this dialog only. Then Update & rerun sends the full timeline to the server."
+                            : "Sends the full event timeline to the server and recomputes score, timeouts, fouls, and clocks."}
+                        </p>
+                      </div>
+                    </>
+                  );
+                })()}
+              </div>
+            </div>
+          )}
+
           {timeoutsModalOpen && (
             <div
               className="game-sheet-modal-overlay"
@@ -909,7 +1585,19 @@ export function GameSheet() {
                         <td>{row.time}</td>
                         <td>{row.cap}</td>
                         <td>{row.team}</td>
-                        <td>{row.remark}</td>
+                        <td>
+                          {row.editable ? (
+                            <button
+                              type="button"
+                              className="scoreboard-timeouts-link"
+                              onClick={() => openProgressEditForRow(row.id)}
+                            >
+                              {row.remark}
+                            </button>
+                          ) : (
+                            row.remark
+                          )}
+                        </td>
                         <td>{row.score}</td>
                       </tr>
                     ))
@@ -1279,6 +1967,160 @@ function parseTimeToSeconds(time: string): number {
   const seconds = Number(sStr || "0");
   if (isNaN(minutes) || isNaN(seconds)) return 0;
   return minutes * 60 + seconds;
+}
+
+function formatGameClockTimeForInput(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m === 0 && s > 0) return `.${s.toString().padStart(2, "0")}`;
+  if (m === 0 && s === 0) return "0";
+  return `${m}.${s.toString().padStart(2, "0")}`;
+}
+
+function parseOptionalGameClockTime(
+  raw: string
+):
+  | { ok: true; seconds: number | undefined }
+  | { ok: false; error: string } {
+  const t = raw.trim().replace(/:/g, ".");
+  if (t === "") return { ok: true, seconds: undefined };
+  if (!/^(\d+\.\d{1,2}|\d+|\.\d{1,2})$/.test(t)) {
+    return {
+      ok: false,
+      error:
+        "Invalid game clock. Use scoring time: minutes.seconds (e.g. 6.50 or 6:50), minutes only (6), or seconds only (.03).",
+    };
+  }
+  return { ok: true, seconds: parseTimeToSeconds(t) };
+}
+
+function teamSideToScoringChar(side: TeamSide): "b" | "w" {
+  return side === "HOME" ? "b" : "w";
+}
+
+/** Time prefix for scoring-command preview; empty if field blank or invalid while typing. */
+function clockPrefixForPreview(raw: string): string {
+  if (raw.trim() === "") return "";
+  const parsed = parseOptionalGameClockTime(raw);
+  if (!parsed.ok || parsed.seconds === undefined) return "";
+  return formatGameClockTimeForInput(parsed.seconds);
+}
+
+type ScoringCommandPreviewResult = {
+  command: string;
+  note?: string;
+};
+
+function buildGoalCommandPreview(
+  side: TeamSide,
+  cap: string,
+  timeRaw: string
+): ScoringCommandPreviewResult {
+  const prefix = clockPrefixForPreview(timeRaw);
+  const capPart = cap.trim() || "?";
+  const command = `${prefix}${teamSideToScoringChar(side)}${capPart}g`;
+  const invalidClock = timeRaw.trim() !== "" && prefix === "";
+  return {
+    command,
+    note: invalidClock
+      ? "Enter a valid game clock to include time in the preview."
+      : undefined,
+  };
+}
+
+function buildExclusionCommandPreview(
+  teamSide: TeamSide,
+  cap: string,
+  timeRaw: string,
+  isPenalty: boolean
+): ScoringCommandPreviewResult {
+  const prefix = clockPrefixForPreview(timeRaw);
+  const capPart = cap.trim() || "?";
+  const action = isPenalty ? "p" : "e";
+  const command = `${prefix}${teamSideToScoringChar(teamSide)}${capPart}${action}`;
+  const invalidClock = timeRaw.trim() !== "" && prefix === "";
+  return {
+    command,
+    note: invalidClock
+      ? "Enter a valid game clock to include time in the preview."
+      : undefined,
+  };
+}
+
+function buildTimeoutCommandPreview(
+  side: TeamSide,
+  isShort: boolean,
+  timeSeconds: number | undefined
+): ScoringCommandPreviewResult {
+  const c = teamSideToScoringChar(side);
+  const mid = isShort ? "t3" : "t";
+  if (typeof timeSeconds === "number" && Number.isFinite(timeSeconds)) {
+    return {
+      command: `${formatGameClockTimeForInput(timeSeconds)}${mid}${c}`,
+    };
+  }
+  return {
+    command: `${mid}${c}`,
+    note: isShort
+      ? "Main scoring entry normally includes the clock (e.g. 4.13t3w)."
+      : "Main scoring entry normally includes the clock (e.g. 4.13tw).",
+  };
+}
+
+function buildInsertCommandPreview(
+  kind: "GOAL" | "EXCLUSION" | "PENALTY" | "TIMEOUT" | "TIMEOUT_30",
+  side: TeamSide,
+  cap: string,
+  timeRaw: string
+): ScoringCommandPreviewResult {
+  const prefix = clockPrefixForPreview(timeRaw);
+  const invalidClock = timeRaw.trim() !== "" && prefix === "";
+  const clockNote = invalidClock
+    ? "Enter a valid game clock to include time in the preview."
+    : undefined;
+  const c = teamSideToScoringChar(side);
+
+  if (kind === "GOAL") {
+    const capPart = cap.trim() || "?";
+    return { command: `${prefix}${c}${capPart}g`, note: clockNote };
+  }
+  if (kind === "EXCLUSION") {
+    const capPart = cap.trim() || "?";
+    return { command: `${prefix}${c}${capPart}e`, note: clockNote };
+  }
+  if (kind === "PENALTY") {
+    const capPart = cap.trim() || "?";
+    return { command: `${prefix}${c}${capPart}p`, note: clockNote };
+  }
+  if (kind === "TIMEOUT_30") {
+    if (prefix !== "") return { command: `${prefix}t3${c}`, note: clockNote };
+    return {
+      command: `t3${c}`,
+      note: clockNote ?? "Main scoring entry normally includes the clock (e.g. 4.13t3w).",
+    };
+  }
+  if (prefix !== "") return { command: `${prefix}t${c}`, note: clockNote };
+  return {
+    command: `t${c}`,
+    note: clockNote ?? "Main scoring entry normally includes the clock (e.g. 4.13tw).",
+  };
+}
+
+function ScoringCommandPreviewBlock({
+  command,
+  note,
+}: ScoringCommandPreviewResult) {
+  return (
+    <p className="game-sheet-progress-command-preview">
+      <span className="game-sheet-progress-command-preview-label">
+        Scoring command (main entry syntax)
+      </span>
+      <code className="game-sheet-progress-command-preview-code">{command}</code>
+      {note ? (
+        <span className="game-sheet-progress-command-preview-note">{note}</span>
+      ) : null}
+    </p>
+  );
 }
 
 function describeParsed(parsed: ParsedInput): string {

--- a/ui/src/pages/NewGameDay.tsx
+++ b/ui/src/pages/NewGameDay.tsx
@@ -46,7 +46,9 @@ export function NewGameDay() {
       </header>
 
       <form onSubmit={handleSubmit} className="form">
-        {error && <p className="error">{formatApiErrorMessage(error)}</p>}
+        {error != null ? (
+          <p className="error">{formatApiErrorMessage(error)}</p>
+        ) : null}
         <label>
           Date
           <input


### PR DESCRIPTION
## Game progress timeline editing and event-log rebuild

### Summary

This work lets operators correct the game event timeline from the sheet (edit, delete, or insert rows), then save by **`POST /games/:id/event-log/rebuild`**, which resets derived state and **reruns** the full ordered event list so scores, fouls, timeouts, and clocks stay consistent with history. The game sheet exposes this through a **progress edit modal** opened from the Remark column, with clearer UX for scoring-style **clock** entry and for the **insert → save** flow.

### Server

- Adds **`rebuildGameFromEventLog`** (transactional reset + ordered re-application) and shared rerun logic in **`gameEventRerun.ts`**.
- New route and **Zod** body for rebuilding the event log; **`api.games.rebuildEventLog`** on the client.
- **TypeScript:** **`tsconfig.build.json`** excludes `*.test.ts` from `dist/`; root **`tsconfig.json`** typechecks tests with **`noEmit`**, **`build`** uses the build config.
- **`gameEventRerun.sort.test.ts`** — unit test for stable sort used before rerun.

### UI (GameSheet)

- **Modal:** edit goal / exclusion–penalty / timeout fields; **delete** row (with guardrails); **insert before/after** with structured fields and **Add to timeline**.
- **Clock fields** use the same semantics as the main scoring command (`6.50` / `6:50` as minutes and seconds in the period), not raw total seconds.
- **Scoring command preview** (`6.30w13g` style) mirrors main-field syntax for goals, exclusions, timeouts, and insert flow.
- **Layout:** wider modal, two-column form grid where helpful, scrollable body, **sticky footer** so **Update & rerun** stays visible.
- **Insert flow:** **Update & rerun** stays **disabled** until **Add to timeline** runs; muted disabled styling and copy (**Add to timeline first…**).
- **Build:** `unknown`-typed error guards fixed in form pages (`error != null ? …`) for **React 19** + **`tsc`**.

### How to verify

- Open a game sheet → **Game progress** → Remark on an event → edit fields and **Update & rerun**; confirm aggregate/progress updates.
- Insert before/after → fill form → **Add to timeline** → **Update & rerun**; confirm new row and server state.
- **Server:** `npm run build` and `npm test` in **`/server`**.

### Notes

- Copy uses **“Update & rerun”** (not “replay”) per product wording.