### PR TITLE
Added a scoreboard only page.

### DIFF
--- a/server/src/routes/games.ts
+++ b/server/src/routes/games.ts
@@ -10,6 +10,7 @@ import {
   gameDayIdParamSchema,
   gameIdParamSchema,
   setClockBodySchema,
+  setGamePeriodBodySchema,
   triggerHornBodySchema,
   updateGameBodySchema,
   updateGameDayBodySchema,
@@ -185,6 +186,12 @@ export async function registerGameRoutes(app: FastifyInstance) {
   app.post("/games/:id/period/advance", async (request) => {
     const params = gameIdParamSchema.parse(request.params);
     return service.advancePeriod(params.id);
+  });
+
+  app.post("/games/:id/period/set", async (request) => {
+    const params = gameIdParamSchema.parse(request.params);
+    const body = setGamePeriodBodySchema.parse(request.body);
+    return service.setGamePeriod(params.id, body.period);
   });
 
   // Roster

--- a/server/src/schemas/game.schemas.ts
+++ b/server/src/schemas/game.schemas.ts
@@ -58,6 +58,10 @@ export const setClockBodySchema = z.object({
   remainingMs: z.number().int().nonnegative(),
 });
 
+export const setGamePeriodBodySchema = z.object({
+  period: z.number().int().min(1),
+});
+
 export const addPlayerBodySchema = z.object({
   capNumber: z.string().min(1), // e.g. "1", "A", "1A"
   playerName: z.string().min(1),

--- a/server/src/services/game.service.ts
+++ b/server/src/services/game.service.ts
@@ -709,6 +709,87 @@ export class GameService {
     return this.emitState(gameId);
   }
 
+  async setGamePeriod(gameId: string, targetPeriod: number) {
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      include: { score: true, gameClock: true, shotClock: true },
+    });
+    if (!game) {
+      throw this.notFound("Game not found");
+    }
+
+    const expandToOvertime = game.totalPeriods === 4 && targetPeriod === 5;
+    if (targetPeriod < 1 || (targetPeriod > game.totalPeriods && !expandToOvertime)) {
+      throw this.badRequest("Invalid period for this game");
+    }
+
+    if (game.gameClock?.running) {
+      await this.stopGameClock(gameId);
+    }
+    if (game.shotClock?.running) {
+      await this.stopShotClock(gameId);
+    }
+
+    if (expandToOvertime) {
+      const from = game.currentPeriod;
+      await this.prisma.game.update({
+        where: { id: gameId },
+        data: {
+          totalPeriods: 5,
+          currentPeriod: 5,
+          status: GameStatus.IN_PROGRESS,
+        },
+      });
+      const payload: Record<string, unknown> = {
+        from,
+        to: 5,
+        directSet: true,
+      };
+      if (game.score) {
+        payload.homeScore = game.score.homeScore;
+        payload.awayScore = game.score.awayScore;
+      }
+      await this.createEvent(
+        gameId,
+        GameEventType.PERIOD_ADVANCED,
+        payload as Prisma.InputJsonValue,
+        "operator"
+      );
+      return this.emitState(gameId);
+    }
+
+    const from = game.currentPeriod;
+    if (from !== targetPeriod) {
+      // Scoreboard distinguishes Q4 (last quarter in progress) from game ended; FINAL is PATCH only.
+      const data: { currentPeriod: number; status: GameStatus } = {
+        currentPeriod: targetPeriod,
+        status: GameStatus.IN_PROGRESS,
+      };
+      await this.prisma.game.update({
+        where: { id: gameId },
+        data,
+      });
+
+      const payload: Record<string, unknown> = {
+        from,
+        to: targetPeriod,
+        directSet: true,
+      };
+      if (game.score) {
+        payload.homeScore = game.score.homeScore;
+        payload.awayScore = game.score.awayScore;
+      }
+      await this.createEvent(
+        gameId,
+        GameEventType.PERIOD_ADVANCED,
+        payload as Prisma.InputJsonValue,
+        "operator"
+      );
+    }
+
+    return this.emitState(gameId);
+  }
+
   async startOvertime(gameId: string) {
     const game = await this.prisma.game.findUnique({
       where: { id: gameId },

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
-        "lucide-react": "^1.7.0",
+        "lucide-react": "^1.8.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1",
@@ -2687,9 +2687,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
-      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "lucide-react": "^1.7.0",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1",

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -1525,6 +1525,28 @@
   }
 }
 
+.games-section .btn.btn-scoreboard-tally {
+  background: #1565c0;
+  color: #fff;
+}
+
+.games-section .btn.btn-scoreboard-tally:hover {
+  background: #0d47a1;
+  color: #fff;
+}
+
+@media (prefers-color-scheme: light) {
+  .games-section .btn.btn-scoreboard-tally {
+    background: #1976d2;
+    color: #fff;
+  }
+
+  .games-section .btn.btn-scoreboard-tally:hover {
+    background: #1565c0;
+    color: #fff;
+  }
+}
+
 .games-section .btn.btn-settings-gear {
   color: #646cff;
 }
@@ -1776,4 +1798,254 @@
 
 .modal-actions {
   justify-content: flex-end;
+}
+
+/* Scoreboard-only control page (home = dark, away = light) */
+.scoreboard-control-page {
+  max-width: 960px;
+}
+
+.scoreboard-control-header {
+  margin-bottom: 1.25rem;
+}
+
+.scoreboard-control-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.scoreboard-control-nav-secondary {
+  opacity: 0.85;
+}
+
+.scoreboard-control-title {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.25rem, 4vw, 1.65rem);
+  line-height: 1.2;
+}
+
+.scoreboard-control-sub {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  opacity: 0.88;
+  max-width: 52ch;
+}
+
+.scoreboard-control-error {
+  margin-bottom: 1rem;
+}
+
+.scoreboard-control-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 520px) {
+  .page.scoreboard-control-page {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .scoreboard-control-page .scoreboard-control-columns {
+    gap: 0.5rem;
+  }
+
+  .scoreboard-control-page .scoreboard-control-side {
+    padding: 0.65rem 0.5rem 0.85rem;
+    min-height: 0;
+    border-radius: 12px;
+  }
+
+  .scoreboard-control-page .scoreboard-control-team-label {
+    font-size: 0.65rem;
+  }
+
+  .scoreboard-control-page .scoreboard-control-team-name {
+    font-size: clamp(0.8rem, 3.5vw, 1rem);
+    margin-bottom: 0.45rem;
+  }
+
+  .scoreboard-control-page .scoreboard-control-score {
+    font-size: clamp(1.85rem, 11vw, 2.75rem);
+    margin-bottom: 0.6rem;
+  }
+
+  .scoreboard-control-page .scoreboard-control-score-btns {
+    gap: 0.4rem;
+    max-width: 100%;
+  }
+
+  .scoreboard-control-page .scoreboard-control-big-btn {
+    min-height: 2.65rem;
+    font-size: 1.1rem;
+  }
+}
+
+.scoreboard-control-side {
+  border-radius: 14px;
+  padding: 1rem 1rem 1.25rem;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+@media (prefers-color-scheme: light) {
+  .scoreboard-control-side {
+    border-color: rgba(0, 0, 0, 0.1);
+  }
+}
+
+.scoreboard-control-side--dark {
+  background: linear-gradient(165deg, #1a2332 0%, #0d1118 100%);
+  color: #f0f4fa;
+}
+
+.scoreboard-control-side--light {
+  background: linear-gradient(165deg, #f5f7fb 0%, #e2e8f0 100%);
+  color: #1a202c;
+}
+
+@media (prefers-color-scheme: light) {
+  .scoreboard-control-side--light {
+    background: linear-gradient(165deg, #fff 0%, #eef2f7 100%);
+  }
+}
+
+.scoreboard-control-team-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.75;
+  margin-bottom: 0.25rem;
+}
+
+.scoreboard-control-team-name {
+  font-weight: 700;
+  font-size: clamp(1rem, 3vw, 1.2rem);
+  line-height: 1.25;
+  margin-bottom: 0.75rem;
+  word-break: break-word;
+}
+
+.scoreboard-control-score {
+  font-size: clamp(2.75rem, 12vw, 4rem);
+  font-weight: 800;
+  line-height: 1;
+  margin-bottom: 1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.scoreboard-control-score-btns {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  width: 100%;
+  max-width: 220px;
+}
+
+.scoreboard-control-big-btn {
+  min-height: 3.25rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
+}
+
+.scoreboard-control-big-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.scoreboard-control-side--dark .scoreboard-control-big-btn--up {
+  background: #2d6a4f;
+  color: #fff;
+}
+
+.scoreboard-control-side--dark .scoreboard-control-big-btn--up:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+.scoreboard-control-side--dark .scoreboard-control-big-btn--down {
+  background: #4a5568;
+  color: #fff;
+}
+
+.scoreboard-control-side--dark .scoreboard-control-big-btn--down:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+.scoreboard-control-side--light .scoreboard-control-big-btn--up {
+  background: #0d9488;
+  color: #fff;
+}
+
+.scoreboard-control-side--light .scoreboard-control-big-btn--up:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.scoreboard-control-side--light .scoreboard-control-big-btn--down {
+  background: #94a3b8;
+  color: #0f172a;
+}
+
+.scoreboard-control-side--light .scoreboard-control-big-btn--down:hover:not(:disabled) {
+  filter: brightness(0.97);
+}
+
+.scoreboard-control-period {
+  margin-top: 0.5rem;
+}
+
+.scoreboard-control-period-heading {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.scoreboard-control-period-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .scoreboard-control-period-grid {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+}
+
+.scoreboard-control-phase-btn {
+  min-height: 2.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  border-radius: 8px;
+  padding: 0.35rem 0.5rem;
+}
+
+.scoreboard-control-phase-btn.is-active {
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.65);
+}
+
+@media (prefers-color-scheme: light) {
+  .scoreboard-control-phase-btn.is-active {
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.55);
+  }
+}
+
+.scoreboard-control-period-note {
+  margin: 0.65rem 0 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  opacity: 0.78;
+  max-width: 56ch;
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { AddGame } from "./pages/AddGame";
 import { EditGame } from "./pages/EditGame";
 import { GameRoster } from "./pages/GameRoster";
 import { GameSheet } from "./pages/GameSheet";
+import { ScoreboardControl } from "./pages/ScoreboardControl";
 import "./App.css";
 
 function App() {
@@ -22,6 +23,7 @@ function App() {
           <Route path="/game-days/:id/games/:gameId/edit" element={<EditGame />} />
           <Route path="/game-days/:id/games/:gameId/roster" element={<GameRoster />} />
           <Route path="/game-days/:id/games/:gameId/sheet" element={<GameSheet />} />
+          <Route path="/game-days/:id/games/:gameId/scoreboard" element={<ScoreboardControl />} />
         </Routes>
       </div>
     </BrowserRouter>

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -22,14 +22,15 @@ async function request<T>(
   options: (Omit<RequestInit, "body"> & { method?: string; json?: unknown }) = {}
 ): Promise<T> {
   const { method = "GET", json, ...rest } = options;
+  const hasJsonBody = json !== undefined;
   const res = await fetch(`${API_BASE}${path}`, {
     ...rest,
     method,
     headers: {
-      "Content-Type": "application/json",
+      ...(hasJsonBody ? { "Content-Type": "application/json" } : {}),
       ...rest.headers,
     },
-    body: json != null ? JSON.stringify(json) : undefined,
+    body: hasJsonBody ? JSON.stringify(json) : undefined,
   });
   if (!res.ok) {
     const text = await res.text();
@@ -108,6 +109,44 @@ export interface GameAggregate {
   }[];
 }
 
+/**
+ * Older servers may not expose POST /games/:id/period/set. Uses clock stops + repeated
+ * period/advance (and optional status FINAL) to approximate setGamePeriod for forward moves only.
+ */
+async function setPeriodFallback(id: string, targetPeriod: number): Promise<GameAggregate> {
+  let agg = await request<GameAggregate>(`/games/${id}`);
+  const tp = agg.totalPeriods;
+  if (targetPeriod < 1 || targetPeriod > tp) {
+    throw new ApiError("Invalid period for this game", 400);
+  }
+
+  await request(`/games/${id}/game-clock/stop`, { method: "POST" }).catch(() => undefined);
+  await request(`/games/${id}/shot-clock/stop`, { method: "POST" }).catch(() => undefined);
+
+  agg = await request<GameAggregate>(`/games/${id}`);
+  let cp = agg.currentPeriod;
+
+  if (cp > targetPeriod) {
+    throw new ApiError(
+      "Moving to an earlier period requires a newer API (POST /api/games/:id/period/set). Redeploy or restart the server, or use the game sheet.",
+      400
+    );
+  }
+
+  let guard = 0;
+  while (cp < targetPeriod && guard < 16) {
+    guard += 1;
+    agg = await request<GameAggregate>(`/games/${id}/period/advance`, { method: "POST" });
+    cp = agg.currentPeriod;
+  }
+
+  if (cp < targetPeriod) {
+    throw new ApiError("Could not reach the selected period. Try again or update the server.", 500);
+  }
+
+  return agg;
+}
+
 export const api = {
   capabilities: () =>
     request<DeviceCapabilities>("/capabilities"),
@@ -175,6 +214,27 @@ export const api = {
         method: "POST",
         json: body,
       }),
+    setPeriod: async (id: string, period: number) => {
+      try {
+        return await request<GameAggregate>(`/games/${id}/period/set`, {
+          method: "POST",
+          json: { period },
+        });
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 404) {
+          return setPeriodFallback(id, period);
+        }
+        throw e;
+      }
+    },
+    scoreHomeIncrement: (id: string) =>
+      request<GameAggregate>(`/games/${id}/score/home/increment`, { method: "POST" }),
+    scoreHomeDecrement: (id: string) =>
+      request<GameAggregate>(`/games/${id}/score/home/decrement`, { method: "POST" }),
+    scoreAwayIncrement: (id: string) =>
+      request<GameAggregate>(`/games/${id}/score/away/increment`, { method: "POST" }),
+    scoreAwayDecrement: (id: string) =>
+      request<GameAggregate>(`/games/${id}/score/away/decrement`, { method: "POST" }),
     rebuildEventLog: (
       id: string,
       body: {

--- a/ui/src/pages/GameDayDetail.tsx
+++ b/ui/src/pages/GameDayDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ClipboardList, Settings, UserRoundCheck } from "lucide-react";
+import { ClipboardList, Settings, Tally5, UserRoundCheck } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import { api } from "../api/client";
 import type { GameDay, GameOnDay } from "../types/gameDay";
@@ -50,13 +50,14 @@ export function GameDayDetail() {
               <th>Gender</th>
               <th>Roster</th>
               <th>Game sheet</th>
+              <th>Scoreboard</th>
               <th>Settings</th>
             </tr>
           </thead>
           <tbody>
             {gameDay.games.length === 0 ? (
               <tr>
-              <td colSpan={10}>No games. Add one below.</td>
+              <td colSpan={11}>No games. Add one below.</td>
               </tr>
             ) : (
               gameDay.games.map((g) => (
@@ -115,6 +116,16 @@ function GameRow({
           title="Edit Game Sheet"
         >
           <ClipboardList size={16} strokeWidth={2} aria-hidden />
+        </Link>
+      </td>
+      <td className="games-action-cell">
+        <Link
+          to={`/game-days/${gameDayId}/games/${game.id}/scoreboard`}
+          className="btn btn-compact btn-games-row-action btn-scoreboard-tally"
+          aria-label="Scoreboard"
+          title="Scoreboard"
+        >
+          <Tally5 size={16} strokeWidth={2} aria-hidden />
         </Link>
       </td>
       <td className="games-action-cell">

--- a/ui/src/pages/GameSheet.tsx
+++ b/ui/src/pages/GameSheet.tsx
@@ -791,6 +791,12 @@ export function GameSheet() {
       <header className="page-header game-sheet-page-header">
         <div className="game-sheet-page-header-back">
           <Link to={gameDayId ? `/game-days/${gameDayId}` : "/"}>← Back to game day</Link>
+          {gameDayId && gameId ? (
+            <>
+              {" · "}
+              <Link to={`/game-days/${gameDayId}/games/${gameId}/scoreboard`}>Scoreboard only</Link>
+            </>
+          ) : null}
         </div>
         <div className="game-sheet-page-header-title">
           <h1>

--- a/ui/src/pages/ScoreboardControl.tsx
+++ b/ui/src/pages/ScoreboardControl.tsx
@@ -1,0 +1,272 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { io, type Socket } from "socket.io-client";
+import { api, type GameAggregate } from "../api/client";
+import { ApiErrorDisplay } from "../components/DatabaseUnavailable";
+
+export function ScoreboardControl() {
+  const { id: gameDayId, gameId } = useParams<{ id: string; gameId: string }>();
+  const [aggregate, setAggregate] = useState<GameAggregate | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+  const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
+  /** Server only has currentPeriod 3 for both; track which label the operator last chose. */
+  const [period3Choice, setPeriod3Choice] = useState<"half" | "q3" | null>(null);
+
+  useEffect(() => {
+    if (!gameId) return;
+    setLoading(true);
+    let socket: Socket | null = null;
+
+    api.games
+      .getAggregate(gameId)
+      .then((agg) => {
+        setAggregate(agg);
+        socket = io(import.meta.env.VITE_SOCKET_URL ?? "http://localhost:3000", {
+          transports: ["websocket"],
+        });
+        socket.emit("game:join", { gameId });
+        socket.on("game:stateUpdated", (payload: { gameId: string; aggregate: GameAggregate }) => {
+          if (payload.gameId === gameId) {
+            setAggregate(payload.aggregate);
+          }
+        });
+      })
+      .catch((e) => setError(e))
+      .finally(() => setLoading(false));
+
+    return () => {
+      if (socket) {
+        socket.emit("game:leave", { gameId });
+        socket.disconnect();
+      }
+    };
+  }, [gameId]);
+
+  useEffect(() => {
+    if (aggregate?.currentPeriod !== 3) {
+      setPeriod3Choice(null);
+    }
+  }, [aggregate?.currentPeriod]);
+
+  const run = useCallback(async (fn: () => Promise<GameAggregate>) => {
+    if (!gameId || busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const next = await fn();
+      setAggregate(next);
+    } catch (e) {
+      setError(e);
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, [gameId]);
+
+  if (loading) {
+    return (
+      <div className="page scoreboard-control-page">
+        <p>Loading…</p>
+      </div>
+    );
+  }
+  if (error && !aggregate) {
+    return (
+      <div className="page scoreboard-control-page">
+        <ApiErrorDisplay error={error} />
+      </div>
+    );
+  }
+  if (!gameId || !aggregate) {
+    return (
+      <div className="page scoreboard-control-page">
+        <p>Game not found.</p>
+      </div>
+    );
+  }
+
+  const homeScore = aggregate.score?.homeScore ?? 0;
+  const awayScore = aggregate.score?.awayScore ?? 0;
+  const tp = aggregate.totalPeriods;
+  const cp = aggregate.currentPeriod;
+  const isFinal = aggregate.status === "FINAL";
+
+  const inP3 = !isFinal && cp === 3;
+  const halfTimeActive = inP3 && period3Choice === "half";
+  const q3Active = inP3 && (period3Choice === "q3" || period3Choice === null);
+
+  const phaseActive = {
+    q1: !isFinal && cp === 1,
+    q2: !isFinal && cp === 2,
+    q4: !isFinal && cp === 4 && tp >= 4,
+    ot: !isFinal && cp === 5 && tp >= 5,
+    final: isFinal,
+  };
+
+  return (
+    <div className="page scoreboard-control-page">
+      <header className="scoreboard-control-header">
+        <div className="scoreboard-control-nav">
+          <Link to={gameDayId ? `/game-days/${gameDayId}/games/${gameId}/sheet` : "/"}>
+            ← Game progress
+          </Link>
+          {gameDayId ? (
+            <Link to={`/game-days/${gameDayId}`} className="scoreboard-control-nav-secondary">
+              Game day
+            </Link>
+          ) : null}
+        </div>
+        <h1 className="scoreboard-control-title">
+          {aggregate.homeTeamName} vs {aggregate.awayTeamName}
+        </h1>
+        <p className="scoreboard-control-sub">
+          Same game state as the progress page (Socket.IO updates both). +/− goals here have no cap
+          numbers, so they pair cleanly with someone scoring by cap on the sheet.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="scoreboard-control-error">
+          <ApiErrorDisplay error={error} />
+        </div>
+      ) : null}
+
+      <div className="scoreboard-control-columns">
+        <section className="scoreboard-control-side scoreboard-control-side--dark" aria-label="Home team, dark caps">
+          <div className="scoreboard-control-team-label">Home · Dark</div>
+          <div className="scoreboard-control-team-name">{aggregate.homeTeamName}</div>
+          <div className="scoreboard-control-score">{homeScore}</div>
+          <div className="scoreboard-control-score-btns">
+            <button
+              type="button"
+              className="btn scoreboard-control-big-btn scoreboard-control-big-btn--up"
+              disabled={busy || isFinal}
+              onClick={() => run(() => api.games.scoreHomeIncrement(gameId))}
+            >
+              +1
+            </button>
+            <button
+              type="button"
+              className="btn scoreboard-control-big-btn scoreboard-control-big-btn--down"
+              disabled={busy || isFinal || homeScore <= 0}
+              onClick={() => run(() => api.games.scoreHomeDecrement(gameId))}
+            >
+              −1
+            </button>
+          </div>
+        </section>
+
+        <section className="scoreboard-control-side scoreboard-control-side--light" aria-label="Away team, light caps">
+          <div className="scoreboard-control-team-label">Away · Light</div>
+          <div className="scoreboard-control-team-name">{aggregate.awayTeamName}</div>
+          <div className="scoreboard-control-score">{awayScore}</div>
+          <div className="scoreboard-control-score-btns">
+            <button
+              type="button"
+              className="btn scoreboard-control-big-btn scoreboard-control-big-btn--up"
+              disabled={busy || isFinal}
+              onClick={() => run(() => api.games.scoreAwayIncrement(gameId))}
+            >
+              +1
+            </button>
+            <button
+              type="button"
+              className="btn scoreboard-control-big-btn scoreboard-control-big-btn--down"
+              disabled={busy || isFinal || awayScore <= 0}
+              onClick={() => run(() => api.games.scoreAwayDecrement(gameId))}
+            >
+              −1
+            </button>
+          </div>
+        </section>
+      </div>
+
+      <section className="scoreboard-control-period" aria-label="Quarter or game phase">
+        <h2 className="scoreboard-control-period-heading">Period</h2>
+        <div className="scoreboard-control-period-grid">
+          <button
+            type="button"
+            className={`btn scoreboard-control-phase-btn${phaseActive.q1 ? " is-active" : ""}`}
+            disabled={busy || tp < 1}
+            onClick={() => run(() => api.games.setPeriod(gameId, 1))}
+          >
+            Q1
+          </button>
+          <button
+            type="button"
+            className={`btn scoreboard-control-phase-btn${phaseActive.q2 ? " is-active" : ""}`}
+            disabled={busy || tp < 2}
+            onClick={() => run(() => api.games.setPeriod(gameId, 2))}
+          >
+            Q2
+          </button>
+          <button
+            type="button"
+            className={`btn scoreboard-control-phase-btn${halfTimeActive ? " is-active" : ""}`}
+            disabled={busy || tp < 3}
+            onClick={() =>
+              run(async () => {
+                const next = await api.games.setPeriod(gameId, 3);
+                setPeriod3Choice("half");
+                return next;
+              })
+            }
+          >
+            Half time
+          </button>
+          <button
+            type="button"
+            className={`btn scoreboard-control-phase-btn${q3Active ? " is-active" : ""}`}
+            disabled={busy || tp < 3}
+            onClick={() =>
+              run(async () => {
+                const next = await api.games.setPeriod(gameId, 3);
+                setPeriod3Choice("q3");
+                return next;
+              })
+            }
+          >
+            Q3
+          </button>
+          <button
+            type="button"
+            className={`btn scoreboard-control-phase-btn${phaseActive.q4 ? " is-active" : ""}`}
+            disabled={busy || tp < 4}
+            onClick={() => run(() => api.games.setPeriod(gameId, 4))}
+          >
+            Q4
+          </button>
+          <button
+            type="button"
+            className={`btn scoreboard-control-phase-btn${phaseActive.ot ? " is-active" : ""}`}
+            disabled={busy || isFinal || tp < 4}
+            onClick={() => run(() => api.games.setPeriod(gameId, 5))}
+            title="Overtime (expands to a 5th period if still in regulation)"
+          >
+            OT
+          </button>
+          <button
+            type="button"
+            className={`btn scoreboard-control-phase-btn${phaseActive.final ? " is-active" : ""}`}
+            disabled={busy}
+            onClick={() =>
+              run(async () => {
+                await api.games.setPeriod(gameId, tp);
+                return api.games.update(gameId, { status: "FINAL" });
+              })
+            }
+          >
+            Final
+          </button>
+        </div>
+        <p className="scoreboard-control-period-note">
+          Half time and Q3 both set period 3. Q4 is the last regulation quarter. OT adds period 5 (or
+          selects it if already in overtime). Final ends the game.
+        </p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **dedicated “scoreboard only” control page** so operators can adjust **scores** and **game period** on a large, touch-friendly layout, separate from the full game sheet. The page shows the same live game state as the progress sheet via **Socket.IO** (`game:stateUpdated` after joining the game room).

## UI

- **New route:** `/game-days/:gameDayId/games/:gameId/scoreboard` (`ScoreboardControl` in `App.tsx`).
- **Navigation:** a **Scoreboard** column with a tally icon on **Game day** game rows, and a **“Scoreboard only”** link next to “Back to game day” on **Game sheet**.
- **Behavior:** home/away **+1 / −1** goal buttons (no cap numbers, by design); period controls for **Q1–Q4**, **Half time** vs **Q3** (both map to period 3 with local UI state), **OT**, and **Final** (sets period then `FINAL` status). Substantial new **CSS** for the scoreboard-control layout and responsive behavior.

## API / client

- **Server:** `POST /games/:id/period/set` with body `{ period }`, implemented by `GameService.setGamePeriod`—stops running clocks when needed, validates period (including OT expansion to 5 periods), logs `PERIOD_ADVANCED` with `directSet: true`, and emits updated state.
- **Client:** `api.games.setPeriod`, **score increment/decrement** helpers; **`setPeriod` falls back** on **404** for older servers (forward-only via `period/advance`, with a clear error if the user needs to jump backward). **`request()`** only sends `Content-Type: application/json` when there is a JSON body.

## Other

- **`lucide-react`** bumped (e.g. for the tally icon) and **`package-lock.json`** updated accordingly.