### PR TITLE
updated docker for ui and app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,11 @@ services:
       - "5432:5432"
     volumes:
       - polodeck-postgres-data:/var/lib/postgresql/data
+    networks:
+      - polodeck
 
   polodeck-app:
-    build: .
+    build: ./server
     container_name: polodeck-app
     depends_on:
       - postgres
@@ -25,7 +27,26 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
     command: ["node", "dist/server.js"]
+    networks:
+      - polodeck
+
+  ui:
+    build:
+      context: ./ui
+      args:
+        VITE_API_URL: ${VITE_API_URL:-http://localhost:3000/api}
+        VITE_SOCKET_URL: ${VITE_SOCKET_URL:-http://localhost:3000}
+    container_name: polodeck-ui
+    depends_on:
+      - polodeck-app
+    ports:
+      - "127.0.0.1:8080:80"
+    networks:
+      - polodeck
 
 volumes:
   polodeck-postgres-data:
 
+networks:
+  polodeck:
+    driver: bridge

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-COPY package.json tsconfig.json ./
+COPY package.json tsconfig.json tsconfig.build.json ./
 COPY prisma ./prisma
 COPY src ./src
 

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Builder must install devDependencies (typescript, vite); do not set NODE_ENV=production before npm ci.
+
+# Browser-reachable URLs (override at build: docker compose build --build-arg ...)
+ARG VITE_API_URL=http://localhost:3000/api
+ARG VITE_SOCKET_URL=http://localhost:3000
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_SOCKET_URL=$VITE_SOCKET_URL
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY index.html vite.config.ts tsconfig.json tsconfig.app.json tsconfig.node.json eslint.config.js ./
+COPY public ./public
+COPY src ./src
+
+RUN npm run build
+
+FROM nginx:alpine AS runner
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

Moves Compose to the **repository root**, adds a **production UI image** (Vite build + nginx), wires **Postgres, API, and UI** on a shared Docker network, and fixes the **server image build** by copying `tsconfig.build.json` into the builder stage.

## Motivation

- Run the **full stack** (database + API + static UI) with one `docker compose` from the project root.
- Serve the SPA with **nginx** (gzip, SPA `try_files` fallback).
- Keep **Vite API/socket URLs** configurable at **build time** via compose/build args.

## What changed

| Area | Change |
|------|--------|
| **Compose** | `server/docker-compose.yml` → `docker-compose.yml` at repo root; `polodeck-app` build context set to `./server`. |
| **Networking** | Explicit `polodeck` bridge network for `postgres`, `polodeck-app`, and `ui`. |
| **UI service** | New `ui` service: multi-stage Dockerfile (Node build → nginx), published at **127.0.0.1:8080** → container port 80. |
| **Server Dockerfile** | Copy `tsconfig.build.json` so `npm run build` (`tsc -p tsconfig.build.json`) succeeds in CI/Docker. |
| **UI** | New `ui/Dockerfile`, `ui/nginx.conf`, `ui/.dockerignore`. |

## How to run

From the **repo root**:

```bash
docker compose up --build