### PR TITLE
Setup to use apt cache during install

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,4 +1,4 @@
-## PoloDeck Server
+# PoloDeck Server
 
 PoloDeck is a **local-first water polo scoreboard and game control platform** designed to run on a pool deck using affordable hardware. This `server/` project is the authoritative backend for managing water polo games, clocks, scores, rosters, exclusions, timeouts, horns, and event history.
 
@@ -62,7 +62,7 @@ Returns a shell script that downloads `bootstrap-kiosk.sh` from `http://<host>:8
 curl -fsSL 'http://<LAN-IP>:3000/kb' | sudo bash
 ```
 
-Optional query parameters: `host=<LAN-IP>` (embed correct URLs when `Host` would otherwise be wrong), `kiosk=setup|board|clock|timer` (default `setup` = static setup screen), `gameId=<id>` (with `board`/`clock`/`timer`, open that game’s kiosk URL). Canonical scripts live under [`../pi/kiosk`](../pi/kiosk) and are copied into the web-app image at build time.
+Optional query parameters: `host=<LAN-IP>` (embed correct URLs when `Host` would otherwise be wrong), `kiosk=setup|board|clock|timer` (default `setup` = static setup screen), `gameId=<id>` (with `board`/`clock`/`timer`, open that game’s kiosk URL), `aptProxy=<http://cache:3142>` (Apt-Cacher NG — overrides optional env `POLODECK_PI_APT_PROXY` on the API container). Canonical scripts live under [`../pi/kiosk`](../pi/kiosk) and are copied into the web-app image at build time.
 
 For a guided install (including migrations), prefer from repo root: `./setup/setup.sh`.
 
@@ -151,7 +151,7 @@ All API endpoints are exposed under `/api` except for health.
 
 ### Health
 
-- **GET** `/health`  
+- **GET** `/health`
   Returns simple server status.
 
 Example:
@@ -164,7 +164,7 @@ curl http://localhost:3000/health
 
 ### Game Management
 
-- **POST** `/api/games`  
+- **POST** `/api/games`
   Create a new game.
 
 Request body:
@@ -187,10 +187,10 @@ curl -X POST http://localhost:3000/api/games \
   -d '{"homeTeamName":"Home","awayTeamName":"Away","totalPeriods":4,"gameClockDurationMs":480000,"shotClockDurationMs":30000}'
 ```
 
-- **GET** `/api/games`  
+- **GET** `/api/games`
   List games.
 
-- **GET** `/api/games/:id`  
+- **GET** `/api/games/:id`
   Return full game aggregate including:
   - game
   - score

--- a/api/src/config/env.ts
+++ b/api/src/config/env.ts
@@ -18,6 +18,21 @@ const envSchema = z.object({
     .string()
     .default("180000")
     .transform((v) => parseInt(v, 10)),
+  /** Optional default for Pi installer GET /kb — Apt-Cacher NG base URL (e.g. http://host:3142). */
+  POLODECK_PI_APT_PROXY: z
+    .string()
+    .optional()
+    .transform((v) => {
+      if (v === undefined || v.trim() === "") return undefined;
+      const t = v.trim().replace(/\/$/, "");
+      try {
+        const u = new URL(t);
+        if (u.protocol !== "http:" && u.protocol !== "https:") return undefined;
+        return t;
+      } catch {
+        return undefined;
+      }
+    }),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/api/src/routes/kioskBootstrap.ts
+++ b/api/src/routes/kioskBootstrap.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance, FastifyRequest } from "fastify";
 
+import { env } from "../config/env.js";
+
 /** Published UI port (docker compose maps host 8080 → nginx in web-app). */
 const UI_PORT = 8080;
 
@@ -15,6 +17,19 @@ function publicHost(request: FastifyRequest, q: Record<string, string | undefine
   }
   const h = request.hostname;
   return h && h.length > 0 ? h : "localhost";
+}
+
+/** Apt-Cacher NG base URL for Pi bootstrap (--apt-proxy); query overrides POLODECK_PI_APT_PROXY. */
+function validateAptProxyUrl(raw: string | string[] | undefined): string | undefined {
+  const v = (Array.isArray(raw) ? raw[0] : raw)?.toString().trim();
+  if (!v) return undefined;
+  try {
+    const u = new URL(v);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return undefined;
+    return v.replace(/\/$/, "");
+  } catch {
+    return undefined;
+  }
 }
 
 function validateGameId(raw: string | string[] | undefined): string | undefined {
@@ -66,10 +81,12 @@ function buildKioskChromiumUrl(opts: {
  *   host=<ip-or-dns>   override hostname when curl Host header is wrong
  *   kiosk=setup|board|clock|timer   (default: setup — static setup screen)
  *   gameId=<id>        with board|clock|timer, open that game’s display route
+ *   aptProxy=<url>     Apt-Cacher NG base URL (http://cache:3142); overrides POLODECK_PI_APT_PROXY
  *
  * Examples:
  *   curl -fsSL 'http://LAN:3000/kb' | sudo bash
  *   curl -fsSL 'http://LAN:3000/kb?kiosk=board&gameId=...' | sudo bash
+ *   curl -fsSL 'http://LAN:3000/kb?aptProxy=http://192.168.1.5:3142' | sudo bash
  */
 export async function registerKioskBootstrapRoutes(app: FastifyInstance) {
   app.get("/kb", async (request, reply) => {
@@ -86,17 +103,21 @@ export async function registerKioskBootstrapRoutes(app: FastifyInstance) {
     const artifactsBase = `${webOrigin.replace(/\/$/, "")}/kiosk`;
     const kioskUrl = buildKioskChromiumUrl({ host, role, gameId });
     const bootUrl = `${artifactsBase}/bootstrap-kiosk.sh`;
+    const aptProxy = validateAptProxyUrl(q.aptProxy) ?? env.POLODECK_PI_APT_PROXY;
 
-    const body = [
+    const lines = [
       "#!/usr/bin/env bash",
       "# PoloDeck Pi kiosk — from GET /kb (web UI :8080; API :3000)",
       "set -euo pipefail",
       `curl -fsSL ${shellSingleQuote(bootUrl)} -o /tmp/polodeck-bootstrap.sh`,
       `exec bash /tmp/polodeck-bootstrap.sh -- \\`,
       `  --artifacts-base ${shellSingleQuote(artifactsBase)} \\`,
-      `  --url ${shellSingleQuote(kioskUrl)}`,
-      "",
-    ].join("\n");
+    ];
+    if (aptProxy) {
+      lines.push(`  --apt-proxy ${shellSingleQuote(aptProxy)} \\`);
+    }
+    lines.push(`  --url ${shellSingleQuote(kioskUrl)}`, "");
+    const body = lines.join("\n");
 
     return reply
       .header("Content-Type", "text/x-shellscript; charset=utf-8")

--- a/pi/README.md
+++ b/pi/README.md
@@ -17,10 +17,16 @@ Shell artifacts live in [`kiosk/`](kiosk/). Before building the `web-app` Docker
    - `host` — if the `Host` header would be wrong (e.g. curling via port-forward), set explicit LAN host: `?host=192.168.1.10`
    - `kiosk` — `setup` (default), `board`, `clock`, or `timer`
    - `gameId` — with `kiosk=board|clock|timer`, opens that game’s display URL; without `gameId`, Chromium opens `/kiosk` in the web app.
+   - `aptProxy` — Apt-Cacher NG base URL passed to the Pi before `apt-get`, e.g. `?aptProxy=http://192.168.1.10:3142`. When present, overrides `POLODECK_PI_APT_PROXY` from the deck server `setup/.env`.
 
-3. Reboot if the kiosk service does not start cleanly the first time. If `tty7` is busy, stop the getty on that VT or adjust the unit in `pi/kiosk/polodeck-kiosk.service`.
+3. **APT cache (optional):** If you run [Apt-Cacher NG](https://hub.docker.com/r/sameersbn/apt-cacher-ng) (or compatible) on your LAN, the installer uses it only for its own `apt-get` step (`Acquire::http::Proxy` / `Acquire::https::Proxy`), then removes that snippet so the Pi keeps using normal mirrors afterward—useful for lab installs without pinning Pis to the cache forever.
 
-   The installer now configures Xorg for Raspberry Pi DRM (`modesetting` + `kmsdev`) and disables `getty@tty1` so kiosk boot is reliable on Bookworm-era images.
+   - Set `POLODECK_PI_APT_PROXY` during `./setup/setup.sh` (deck machine), add `?aptProxy=…` to `/kb`, export `POLODECK_APT_PROXY` on the Pi before running the script, pass `--apt-proxy URL` to `bootstrap-kiosk.sh`, or use the interactive prompts (they read from `/dev/tty`, so **`curl … | sudo bash` still prompts** when you have a real terminal—SSH or console).
+   - Typical URL: `http://<cache-host>:3142`.
+
+4. Reboot if the kiosk service does not start cleanly the first time. If `tty7` is busy, stop the getty on that VT or adjust the unit in `pi/kiosk/polodeck-kiosk.service`.
+
+   The installer configures Xorg for Raspberry Pi DRM (`modesetting` + `kmsdev`) and disables `getty@tty1` so kiosk boot is reliable on Bookworm-era images.
 
 ## WiFi (optional)
 

--- a/pi/kiosk/bootstrap-kiosk.sh
+++ b/pi/kiosk/bootstrap-kiosk.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 # PoloDeck Pi kiosk — post-download installer (run as root).
-# Invoked by GET /kb stub with: --artifacts-base URL --url CHROMIUM_START_URL
+# Invoked by GET /kb stub with: --artifacts-base URL --url CHROMIUM_START_URL [--apt-proxy URL]
+# Optional env: POLODECK_APT_PROXY — same as --apt-proxy (Apt-Cacher NG: http://host:3142).
 set -euo pipefail
 
 ARTIFACTS=""
 KIOSK_URL=""
+APT_PROXY_URL=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --artifacts-base) ARTIFACTS="${2:?}"; shift 2 ;;
     --url) KIOSK_URL="${2:?}"; shift 2 ;;
+    --apt-proxy) APT_PROXY_URL="${2:?}"; shift 2 ;;
     --) shift; continue ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
@@ -21,7 +24,7 @@ if [[ "$(id -u)" != "0" ]]; then
 fi
 
 if [[ -z "${ARTIFACTS}" || -z "${KIOSK_URL}" ]]; then
-  echo "Usage: sudo bash bootstrap-kiosk.sh -- --artifacts-base URL --url CHROMIUM_URL" >&2
+  echo "Usage: sudo bash bootstrap-kiosk.sh -- --artifacts-base URL --url CHROMIUM_URL [--apt-proxy http://cache:3142]" >&2
   exit 1
 fi
 
@@ -29,6 +32,63 @@ if ! test -r /proc/device-tree/model || ! grep -qi raspberry /proc/device-tree/m
   echo "This installer is only supported on Raspberry Pi hardware." >&2
   exit 1
 fi
+
+# curl … | sudo bash leaves stdin non-interactive; read prompts from /dev/tty when available.
+read_console() {
+  if [[ -t 0 ]]; then
+    read -r "$@"
+  elif [[ -r /dev/tty ]]; then
+    read -r "$@" </dev/tty
+  else
+    return 1
+  fi
+}
+
+interactive_console() {
+  [[ -t 2 ]] && { [[ -t 0 ]] || [[ -r /dev/tty ]]; }
+}
+
+if [[ -z "${APT_PROXY_URL}" && -n "${POLODECK_APT_PROXY:-}" ]]; then
+  APT_PROXY_URL="${POLODECK_APT_PROXY}"
+fi
+
+if [[ -z "${APT_PROXY_URL}" ]] && interactive_console; then
+  echo "" >&2
+  read_console -r -p "Use apt HTTP proxy (e.g. Apt-Cacher NG on port 3142)? [y/N] " use_proxy || true
+  use_lc="$(printf '%s' "${use_proxy:-}" | tr '[:upper:]' '[:lower:]')"
+  case "${use_lc}" in
+    y|yes)
+      read_console -r -p "APT proxy base URL (e.g. http://192.168.1.10:3142): " APT_PROXY_URL || true
+      APT_PROXY_URL="$(printf '%s' "${APT_PROXY_URL:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+      ;;
+  esac
+fi
+
+POLODECK_APT_PROXY_CONF="/etc/apt/apt.conf.d/99polodeck-apt-proxy.conf"
+
+configure_apt_proxy() {
+  local u="$1"
+  u="${u%/}"
+  if [[ -z "${u}" ]]; then
+    return 0
+  fi
+  case "${u}" in
+    http://*|https://*) ;;
+    *)
+      echo "error: apt proxy URL must start with http:// or https:// (got: ${u})" >&2
+      exit 1
+      ;;
+  esac
+  if [[ "${u}" == *\"* || "${u}" == *\'* || "${u}" == *\`* || "${u}" == *$'\n'* || "${u}" == *$'\r'* ]]; then
+    echo "error: apt proxy URL contains unsupported characters" >&2
+    exit 1
+  fi
+  printf 'Acquire::http::Proxy "%s";\nAcquire::https::Proxy "%s";\n' "${u}" "${u}" >"${POLODECK_APT_PROXY_CONF}"
+  chmod 644 "${POLODECK_APT_PROXY_CONF}"
+  echo "APT proxy configured (http + https via cache): ${u}"
+}
+
+configure_apt_proxy "${APT_PROXY_URL:-}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
@@ -38,6 +98,11 @@ apt-get install -y \
   curl \
   network-manager \
   || { echo "apt-get install failed." >&2; exit 1; }
+
+if [[ -f "${POLODECK_APT_PROXY_CONF}" ]]; then
+  rm -f "${POLODECK_APT_PROXY_CONF}"
+  echo "Removed transient APT proxy config; future apt uses default mirrors."
+fi
 
 if ! id polodeck &>/dev/null; then
   useradd -m -s /bin/bash -G video,tty,input,audio,render polodeck
@@ -104,9 +169,9 @@ systemctl restart polodeck-kiosk.service || systemctl start polodeck-kiosk.servi
 
 echo "PoloDeck kiosk installed. Chromium URL: ${KIOSK_URL}"
 
-if [[ -t 0 ]] && [[ -t 1 ]]; then
-  echo
-  read -r -p "Reboot the Pi now to finish setup? [y/N] " reply || true
+if interactive_console; then
+  echo >&2
+  read_console -r -p "Reboot the Pi now to finish setup? [y/N] " reply || true
   reply_lc="$(printf '%s' "${reply:-}" | tr '[:upper:]' '[:lower:]')"
   case "${reply_lc}" in
     y|yes)

--- a/setup/.env.example
+++ b/setup/.env.example
@@ -5,6 +5,11 @@
 # 127.0.0.1 = localhost only. 0.0.0.0 = all interfaces (LAN / Raspberry Pi clients).
 POLODECK_BIND_ADDRESS=0.0.0.0
 
+# Optional: Apt-Cacher NG (or compatible) base URL for Pi kiosk installs via GET /kb.
+# Example Docker Hub image: sameersbn/apt-cacher-ng — default listen port 3142.
+# Leave empty to skip; Pi can still use an interactive prompt or ?aptProxy= on /kb.
+# POLODECK_PI_APT_PROXY=http://192.168.1.10:3142
+
 # Postgres (defaults match docker-compose.yml).
 POSTGRES_USER=polodeck
 POSTGRES_PASSWORD=polodeck

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       NODE_ENV: production
       PORT: 3000
       DATABASE_URL: postgresql://${POSTGRES_USER:-polodeck}:${POSTGRES_PASSWORD:-polodeck}@postgres:5432/${POSTGRES_DB:-polodeck}?schema=public
+      POLODECK_PI_APT_PROXY: ${POLODECK_PI_APT_PROXY:-}
     ports:
       # Use POLODECK_BIND_ADDRESS=0.0.0.0 so Pis and other PCs on the LAN can reach the API and Socket.IO.
       - "${POLODECK_BIND_ADDRESS:-127.0.0.1}:3000:3000"

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -13,8 +13,8 @@ usage() {
 PoloDeck setup (Docker)
 
   ./setup/setup.sh              First-time: copy .env from example, prompt for LAN bind, start stack + migrations
-  ./setup/setup.sh install      Same as no args (non-interactive if stdin is not a TTY)
-  ./setup/setup.sh config       Only create/update .env (interactive when TTY)
+  ./setup/setup.sh install      Same as no args (non-interactive if no usable console)
+  ./setup/setup.sh config       Only create/update .env (interactive when console available)
   ./setup/setup.sh up           Build and start containers (uses existing .env or copies example)
   ./setup/setup.sh down         Stop and remove containers
   ./setup/setup.sh migrate      Run prisma migrate deploy in the API container
@@ -24,6 +24,7 @@ PoloDeck setup (Docker)
 Environment (non-interactive / CI):
 
   POLODECK_BIND_ADDRESS=0.0.0.0   Skip LAN prompt; use with install/up
+  POLODECK_PI_APT_PROXY=...       Skip Pi APT proxy prompts; passed to API for GET /kb installs
   POLODECK_SETUP_SKIP_START=1   config/install: write .env only, do not run compose
 
 From repo root, quick start:
@@ -63,9 +64,23 @@ ensure_env_file() {
   fi
 }
 
+read_console() {
+  if [[ -t 0 ]]; then
+    read -r "$@"
+  elif [[ -r /dev/tty ]]; then
+    read -r "$@" </dev/tty
+  else
+    return 1
+  fi
+}
+
+setup_can_prompt() {
+  [[ -t 2 ]] && { [[ -t 0 ]] || [[ -r /dev/tty ]]; }
+}
+
 prompt_bind() {
   local bind_default="127.0.0.1"
-  if [[ ! -t 0 ]]; then
+  if ! setup_can_prompt; then
     echo "${POLODECK_BIND_ADDRESS:-${bind_default}}"
     return
   fi
@@ -74,7 +89,7 @@ prompt_bind() {
   echo "  127.0.0.1 — localhost only (default)"
   echo "  0.0.0.0   — all interfaces (other PCs / Raspberry Pis on your pool LAN)"
   echo ""
-  read -r -p "Use LAN binding (0.0.0.0)? [y/N] " LAN
+  read_console -r -p "Use LAN binding (0.0.0.0)? [y/N] " LAN
   if [[ "${LAN,,}" == "y" || "${LAN,,}" == "yes" ]]; then
     echo "0.0.0.0"
   else
@@ -82,12 +97,35 @@ prompt_bind() {
   fi
 }
 
+# Optional Apt-Cacher NG URL baked into GET /kb for Pi apt-get (sameersbn/apt-cacher-ng default :3142).
+prompt_pi_apt_proxy() {
+  if ! setup_can_prompt; then
+    printf '%s' "${POLODECK_PI_APT_PROXY:-}"
+    return
+  fi
+  echo ""
+  echo "Optional: default APT HTTP proxy for Raspberry Pi kiosk installs (Apt-Cacher NG)."
+  echo "When set, curl …/kb | sudo bash passes this to the Pi before apt-get."
+  echo ""
+  read_console -r -p "Configure default APT proxy for Pi installers? [y/N] " USE_PROXY
+  if [[ "${USE_PROXY,,}" != "y" && "${USE_PROXY,,}" != "yes" ]]; then
+    printf ''
+    return
+  fi
+  read_console -r -p "APT proxy base URL (e.g. http://192.168.1.10:3142): " URL_IN
+  URL_IN="$(printf '%s' "${URL_IN:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  printf '%s' "${URL_IN}"
+}
+
 configure_env_interactive() {
   ensure_env_file
-  local bind
+  local bind proxy
   bind="$(prompt_bind)"
   upsert_env "POLODECK_BIND_ADDRESS" "${bind}" "${ENV_FILE}"
   echo "Updated POLODECK_BIND_ADDRESS=${bind} in ${ENV_FILE}"
+  proxy="$(prompt_pi_apt_proxy)"
+  upsert_env "POLODECK_PI_APT_PROXY" "${proxy}" "${ENV_FILE}"
+  echo "Updated POLODECK_PI_APT_PROXY in ${ENV_FILE}"
 }
 
 run_migrate() {
@@ -115,15 +153,22 @@ cmd_up() {
 
 cmd_install() {
   ensure_env_file
-  if [[ -t 0 ]]; then
-    local bind
+  if setup_can_prompt; then
+    local bind proxy
     bind="$(prompt_bind)"
     upsert_env "POLODECK_BIND_ADDRESS" "${bind}" "${ENV_FILE}"
     echo "Wrote POLODECK_BIND_ADDRESS to ${ENV_FILE}"
+    proxy="$(prompt_pi_apt_proxy)"
+    upsert_env "POLODECK_PI_APT_PROXY" "${proxy}" "${ENV_FILE}"
+    echo "Wrote POLODECK_PI_APT_PROXY to ${ENV_FILE}"
   else
     local bind="${POLODECK_BIND_ADDRESS:-127.0.0.1}"
     upsert_env "POLODECK_BIND_ADDRESS" "${bind}" "${ENV_FILE}"
     echo "Non-interactive: POLODECK_BIND_ADDRESS=${bind} (set env to override)"
+    if [[ -n "${POLODECK_PI_APT_PROXY+x}" ]]; then
+      upsert_env "POLODECK_PI_APT_PROXY" "${POLODECK_PI_APT_PROXY:-}" "${ENV_FILE}"
+      echo "Non-interactive: POLODECK_PI_APT_PROXY=${POLODECK_PI_APT_PROXY:-} (from environment)"
+    fi
   fi
 
   if [[ "${POLODECK_SETUP_SKIP_START:-}" == "1" ]]; then

--- a/web-app/public/kiosk/bootstrap-kiosk.sh
+++ b/web-app/public/kiosk/bootstrap-kiosk.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 # PoloDeck Pi kiosk — post-download installer (run as root).
-# Invoked by GET /kb stub with: --artifacts-base URL --url CHROMIUM_START_URL
+# Invoked by GET /kb stub with: --artifacts-base URL --url CHROMIUM_START_URL [--apt-proxy URL]
+# Optional env: POLODECK_APT_PROXY — same as --apt-proxy (Apt-Cacher NG: http://host:3142).
 set -euo pipefail
 
 ARTIFACTS=""
 KIOSK_URL=""
+APT_PROXY_URL=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --artifacts-base) ARTIFACTS="${2:?}"; shift 2 ;;
     --url) KIOSK_URL="${2:?}"; shift 2 ;;
+    --apt-proxy) APT_PROXY_URL="${2:?}"; shift 2 ;;
     --) shift; continue ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
@@ -21,7 +24,7 @@ if [[ "$(id -u)" != "0" ]]; then
 fi
 
 if [[ -z "${ARTIFACTS}" || -z "${KIOSK_URL}" ]]; then
-  echo "Usage: sudo bash bootstrap-kiosk.sh -- --artifacts-base URL --url CHROMIUM_URL" >&2
+  echo "Usage: sudo bash bootstrap-kiosk.sh -- --artifacts-base URL --url CHROMIUM_URL [--apt-proxy http://cache:3142]" >&2
   exit 1
 fi
 
@@ -29,6 +32,63 @@ if ! test -r /proc/device-tree/model || ! grep -qi raspberry /proc/device-tree/m
   echo "This installer is only supported on Raspberry Pi hardware." >&2
   exit 1
 fi
+
+# curl … | sudo bash leaves stdin non-interactive; read prompts from /dev/tty when available.
+read_console() {
+  if [[ -t 0 ]]; then
+    read -r "$@"
+  elif [[ -r /dev/tty ]]; then
+    read -r "$@" </dev/tty
+  else
+    return 1
+  fi
+}
+
+interactive_console() {
+  [[ -t 2 ]] && { [[ -t 0 ]] || [[ -r /dev/tty ]]; }
+}
+
+if [[ -z "${APT_PROXY_URL}" && -n "${POLODECK_APT_PROXY:-}" ]]; then
+  APT_PROXY_URL="${POLODECK_APT_PROXY}"
+fi
+
+if [[ -z "${APT_PROXY_URL}" ]] && interactive_console; then
+  echo "" >&2
+  read_console -r -p "Use apt HTTP proxy (e.g. Apt-Cacher NG on port 3142)? [y/N] " use_proxy || true
+  use_lc="$(printf '%s' "${use_proxy:-}" | tr '[:upper:]' '[:lower:]')"
+  case "${use_lc}" in
+    y|yes)
+      read_console -r -p "APT proxy base URL (e.g. http://192.168.1.10:3142): " APT_PROXY_URL || true
+      APT_PROXY_URL="$(printf '%s' "${APT_PROXY_URL:-}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+      ;;
+  esac
+fi
+
+POLODECK_APT_PROXY_CONF="/etc/apt/apt.conf.d/99polodeck-apt-proxy.conf"
+
+configure_apt_proxy() {
+  local u="$1"
+  u="${u%/}"
+  if [[ -z "${u}" ]]; then
+    return 0
+  fi
+  case "${u}" in
+    http://*|https://*) ;;
+    *)
+      echo "error: apt proxy URL must start with http:// or https:// (got: ${u})" >&2
+      exit 1
+      ;;
+  esac
+  if [[ "${u}" == *\"* || "${u}" == *\'* || "${u}" == *\`* || "${u}" == *$'\n'* || "${u}" == *$'\r'* ]]; then
+    echo "error: apt proxy URL contains unsupported characters" >&2
+    exit 1
+  fi
+  printf 'Acquire::http::Proxy "%s";\nAcquire::https::Proxy "%s";\n' "${u}" "${u}" >"${POLODECK_APT_PROXY_CONF}"
+  chmod 644 "${POLODECK_APT_PROXY_CONF}"
+  echo "APT proxy configured (http + https via cache): ${u}"
+}
+
+configure_apt_proxy "${APT_PROXY_URL:-}"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
@@ -39,9 +99,15 @@ apt-get install -y \
   network-manager \
   || { echo "apt-get install failed." >&2; exit 1; }
 
-if ! id polodeck &>/dev/null; then
-  useradd -m -s /bin/bash -G video,tty,input,audio polodeck
+if [[ -f "${POLODECK_APT_PROXY_CONF}" ]]; then
+  rm -f "${POLODECK_APT_PROXY_CONF}"
+  echo "Removed transient APT proxy config; future apt uses default mirrors."
 fi
+
+if ! id polodeck &>/dev/null; then
+  useradd -m -s /bin/bash -G video,tty,input,audio,render polodeck
+fi
+usermod -aG video,tty,input,audio,render polodeck
 
 mkdir -p /etc/polodeck-kiosk
 printf '%s\n' "${KIOSK_URL}" >/etc/polodeck-kiosk/url
@@ -61,6 +127,29 @@ chmod 755 /usr/local/bin/polodeck-wifi.sh
 fetch polodeck-kiosk.service /etc/systemd/system/polodeck-kiosk.service
 chmod 644 /etc/systemd/system/polodeck-kiosk.service
 
+cat >/etc/X11/Xwrapper.config <<'XWEOF'
+allowed_users=anybody
+needs_root_rights=yes
+XWEOF
+chmod 644 /etc/X11/Xwrapper.config
+
+KMSDEV="/dev/dri/card0"
+if [[ -e /dev/dri/card1 ]]; then
+  KMSDEV="/dev/dri/card1"
+fi
+mkdir -p /etc/X11/xorg.conf.d
+cat >/etc/X11/xorg.conf.d/99-polodeck-modesetting.conf <<XORGEOF
+Section "Device"
+    Identifier "PolodeckGPU"
+    Driver "modesetting"
+    Option "kmsdev" "${KMSDEV}"
+EndSection
+Section "Module"
+    Disable "fbdev"
+EndSection
+XORGEOF
+chmod 644 /etc/X11/xorg.conf.d/99-polodeck-modesetting.conf
+
 cat >/home/polodeck/.xsession <<'XSEOF'
 #!/bin/sh
 xset s off 2>/dev/null || true
@@ -73,7 +162,26 @@ chown polodeck:polodeck /home/polodeck/.xsession
 chmod 755 /home/polodeck/.xsession
 
 systemctl daemon-reload
+systemctl disable --now getty@tty1.service >/dev/null 2>&1 || true
+systemctl mask getty@tty1.service >/dev/null 2>&1 || true
 systemctl enable polodeck-kiosk.service
 systemctl restart polodeck-kiosk.service || systemctl start polodeck-kiosk.service
 
 echo "PoloDeck kiosk installed. Chromium URL: ${KIOSK_URL}"
+
+if interactive_console; then
+  echo >&2
+  read_console -r -p "Reboot the Pi now to finish setup? [y/N] " reply || true
+  reply_lc="$(printf '%s' "${reply:-}" | tr '[:upper:]' '[:lower:]')"
+  case "${reply_lc}" in
+    y|yes)
+      echo "Rebooting..."
+      reboot
+      ;;
+    *)
+      echo "Skipping reboot. Run 'sudo reboot' (or 'reboot' as root) when ready."
+      ;;
+  esac
+else
+  echo "No interactive terminal (e.g. curl | bash). Run 'sudo reboot' when ready."
+fi

--- a/web-app/public/kiosk/polodeck-kiosk.service
+++ b/web-app/public/kiosk/polodeck-kiosk.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=PoloDeck Chromium kiosk (X11)
-After=network-online.target
-Wants=network-online.target
+# Use network.target (not network-online): Chromium retries the URL; network-online can block or flap on WiFi.
+After=network.target systemd-user-sessions.service
+Wants=network.target
+Conflicts=getty@tty1.service
 
 [Service]
 Type=simple
@@ -10,14 +12,17 @@ Group=polodeck
 WorkingDirectory=/home/polodeck
 Environment=HOME=/home/polodeck
 PAMName=login
-TTYPath=/dev/tty7
-StandardInput=tty
+TTYPath=/dev/tty1
+StandardInput=tty-force
 StandardOutput=tty
 TTYReset=yes
 TTYVHangup=yes
-ExecStart=/usr/bin/xinit /home/polodeck/.xsession -- :0 vt7 -nolisten tcp
+# Cold boot: DRM/KMS nodes are sometimes not ready the instant multi-user starts; avoids blank tty1 + cursor.
+ExecStartPre=/bin/sleep 3
+ExecStart=/usr/bin/xinit /home/polodeck/.xsession -- :0 vt1 -keeptty -nolisten tcp
 Restart=always
 RestartSec=5
 
 [Install]
-WantedBy=graphical.target
+# Lite images default to multi-user.target; graphical.target is not activated on boot, so kiosk would never start.
+WantedBy=multi-user.target graphical.target


### PR DESCRIPTION
Summary
Adds optional use of a local APT cache (e.g. [sameersbn/apt-cacher-ng](https://hub.docker.com/r/sameersbn/apt-cacher-ng) on port 3142) during the PoloDeck Pi kiosk bootstrap. The cache is only used for the installer’s apt-get step; the PoloDeck APT proxy snippet is removed afterward so the Pi keeps using normal mirrors for future updates.

Deck server (setup/)
./setup/setup.sh (interactive install/config): prompts for default APT proxy for Pi installers and writes POLODECK_PI_APT_PROXY to setup/.env.
docker-compose.yml: passes POLODECK_PI_APT_PROXY into the API container.
setup/.env.example: documents the variable (commented).

API
GET /kb: optional query aptProxy=<url> (validated http/https); overrides POLODECK_PI_APT_PROXY when present. Stub script passes --apt-proxy to bootstrap-kiosk.sh when set.
env.ts: optional POLODECK_PI_APT_PROXY with URL validation.

Pi (pi/kiosk/bootstrap-kiosk.sh, synced to web-app/public/kiosk/)
--apt-proxy and env POLODECK_APT_PROXY; writes /etc/apt/apt.conf.d/99polodeck-apt-proxy.conf before apt-get, then deletes it after a successful install.
Interactive prompts for cache URL: reads from /dev/tty when stdin is a pipe so curl … | sudo bash still prompts on a real SSH/console session.

Docs
pi/README.md, api/README.md: APT cache behavior, aptProxy, and transient proxy note.