### PR TITLE
51 pi scoreboardv1

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -62,7 +62,7 @@ Returns a shell script that downloads `bootstrap-kiosk.sh` from `http://<host>:8
 curl -fsSL 'http://<LAN-IP>:3000/kb' | sudo bash
 ```
 
-Optional query parameters: `host=<LAN-IP>` (embed correct URLs when `Host` would otherwise be wrong), `kiosk=setup|board|clock|timer` (default `setup` = static setup screen), `gameId=<id>` (with `board`/`clock`/`timer`, open that game’s kiosk URL), `aptProxy=<http://cache:3142>` (Apt-Cacher NG — overrides optional env `POLODECK_PI_APT_PROXY` on the API container). Canonical scripts live under [`../pi/kiosk`](../pi/kiosk) and are copied into the web-app image at build time.
+Optional query parameters: `host=<LAN-IP>` (embed correct URLs when `Host` would otherwise be wrong), `kiosk=managed|setup|board|clock|timer` (default `managed` = `/kiosk/managed` for server-assigned roles; `setup` = static connectivity screen), `gameId=<id>` (only with `board`/`clock`/`timer`, open that game’s legacy kiosk URL), `aptProxy=<http://cache:3142>` (Apt-Cacher NG — overrides optional env `POLODECK_PI_APT_PROXY` on the API container). Canonical scripts live under [`../pi/kiosk`](../pi/kiosk) and are copied into the web-app image at build time.
 
 For a guided install (including migrations), prefer from repo root: `./setup/setup.sh`.
 

--- a/api/postman/PoloDeck-API.postman_collection.json
+++ b/api/postman/PoloDeck-API.postman_collection.json
@@ -125,7 +125,7 @@
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"clientId\": \"sb-001\",\n  \"type\": \"SCOREBOARD\",\n  \"name\": \"Main scoreboard\"\n}"
+              "raw": "{\n  \"clientId\": \"sb-001\",\n  \"name\": \"Main scoreboard\"\n}"
             },
             "url": "{{baseUrl}}/api/devices/check-in"
           }
@@ -136,6 +136,18 @@
             "method": "GET",
             "header": [],
             "url": "{{baseUrl}}/api/devices"
+          }
+        },
+        {
+          "name": "Patch Device",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"SCOREBOARD\",\n  \"gameId\": \"{{gameId}}\"\n}"
+            },
+            "url": "{{baseUrl}}/api/devices/{{deviceId}}"
           }
         },
         {

--- a/api/prisma/migrations/20260508120000_device_unassigned_game/migration.sql
+++ b/api/prisma/migrations/20260508120000_device_unassigned_game/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum
+ALTER TYPE "DeviceType" ADD VALUE 'UNASSIGNED';
+
+-- AlterTable
+ALTER TABLE "Device" ADD COLUMN     "gameId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "Device" ADD CONSTRAINT "Device_gameId_fkey" FOREIGN KEY ("gameId") REFERENCES "Game"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -24,6 +24,7 @@ enum ExclusionStatus {
 }
 
 enum DeviceType {
+  UNASSIGNED
   SCOREBOARD
   SHOT_CLOCK
   TIMER
@@ -88,6 +89,7 @@ model Game {
   players        Player[]
   exclusions     PlayerExclusion[]
   timeoutStates  TeamTimeoutState[]
+  devices        Device[]
 }
 
 model Score {
@@ -187,9 +189,12 @@ model Device {
   clientId      String     @unique
   type          DeviceType
   name          String?
+  gameId        String?
   lastCheckInAt DateTime
   createdAt     DateTime   @default(now())
   updatedAt     DateTime   @updatedAt
+
+  game          Game?      @relation(fields: [gameId], references: [id], onDelete: SetNull)
 }
 
 

--- a/api/src/routes/games.ts
+++ b/api/src/routes/games.ts
@@ -1,14 +1,17 @@
 import type { FastifyInstance } from "fastify";
-import { TeamSide } from ".prisma/client";
+import { DeviceType, TeamSide } from ".prisma/client";
 import { env } from "../config/env";
 import {
   addPlayerBodySchema,
   createExclusionBodySchema,
   createGameBodySchema,
   createGameDayBodySchema,
+  deviceCheckInBodySchema,
+  deviceIdParamSchema,
   exclusionIdParamSchema,
   gameDayIdParamSchema,
   gameIdParamSchema,
+  patchDeviceBodySchema,
   setClockBodySchema,
   setGamePeriodBodySchema,
   triggerHornBodySchema,
@@ -70,26 +73,9 @@ export async function registerGameRoutes(app: FastifyInstance) {
 
   // Global devices & capabilities (one server -> one game, many devices)
   app.post("/devices/check-in", async (request) => {
-    const body = request.body as {
-      clientId?: string;
-      type?: string;
-      name?: string;
-    };
-
-    if (!body?.clientId || !body?.type) {
-      throw new Error("clientId and type are required");
-    }
-
-    const normalizedType = body.type.toUpperCase();
-    const allowedTypes = ["SCOREBOARD", "SHOT_CLOCK", "TIMER"] as const;
-
-    if (!allowedTypes.includes(normalizedType as any)) {
-      throw new Error("Invalid device type");
-    }
-
+    const body = deviceCheckInBodySchema.parse(request.body);
     const device = await service.checkInDevice({
       clientId: body.clientId,
-      type: normalizedType as (typeof allowedTypes)[number],
       name: body.name,
     });
 
@@ -100,6 +86,16 @@ export async function registerGameRoutes(app: FastifyInstance) {
         staleAfterMs: env.DEVICE_STALE_AFTER_MS,
       },
     };
+  });
+
+  app.patch("/devices/:deviceId", async (request) => {
+    const params = deviceIdParamSchema.parse(request.params);
+    const body = patchDeviceBodySchema.parse(request.body);
+    const type = body.type !== undefined ? (body.type as DeviceType) : undefined;
+    return service.patchDevice(params.deviceId, {
+      type,
+      gameId: body.gameId,
+    });
   });
 
   app.get("/devices", async () => {

--- a/api/src/routes/kioskBootstrap.ts
+++ b/api/src/routes/kioskBootstrap.ts
@@ -39,20 +39,21 @@ function validateGameId(raw: string | string[] | undefined): string | undefined 
   return id;
 }
 
-type KioskRole = "SETUP" | "SCOREBOARD" | "SHOT_CLOCK" | "TIMER";
+type KioskRole = "SETUP" | "MANAGED" | "SCOREBOARD" | "SHOT_CLOCK" | "TIMER";
 
 function parseKioskRole(
   raw: string | string[] | undefined
 ): { ok: true; role: KioskRole } | { ok: false; message: string } {
   const v = (Array.isArray(raw) ? raw[0] : raw)?.toString().trim().toLowerCase() ?? "";
-  if (v === "" || v === "setup") return { ok: true, role: "SETUP" };
+  if (v === "" || v === "managed") return { ok: true, role: "MANAGED" };
+  if (v === "setup") return { ok: true, role: "SETUP" };
   if (v === "board") return { ok: true, role: "SCOREBOARD" };
   if (v === "clock") return { ok: true, role: "SHOT_CLOCK" };
   if (v === "timer") return { ok: true, role: "TIMER" };
   return {
     ok: false,
     message:
-      "Invalid kiosk query. Use kiosk=setup (default), kiosk=board, kiosk=clock, kiosk=timer. Optional: gameId=<id>. Example: /kb?kiosk=clock&gameId=...\n",
+      "Invalid kiosk query. Use kiosk=managed (default), kiosk=setup, kiosk=board, kiosk=clock, kiosk=timer. Optional: gameId=<id> with board|clock|timer. Example: /kb?kiosk=clock&gameId=...\n",
   };
 }
 
@@ -64,6 +65,10 @@ function buildKioskChromiumUrl(opts: {
   const origin = `http://${opts.host}:${UI_PORT}`;
   if (opts.role === "SETUP") {
     return `${origin}/kiosk/setup-screen.html`;
+  }
+  if (opts.role === "MANAGED") {
+    // Static page handles first-registration and redirects to assigned display.
+    return `${origin}/kiosk/setup-screen.html?managed=1`;
   }
   const gid = opts.gameId;
   if (!gid) {
@@ -79,8 +84,8 @@ function buildKioskChromiumUrl(opts: {
  *
  * GET /kb — optional query:
  *   host=<ip-or-dns>   override hostname when curl Host header is wrong
- *   kiosk=setup|board|clock|timer   (default: setup — static setup screen)
- *   gameId=<id>        with board|clock|timer, open that game’s display route
+ *   kiosk=managed|setup|board|clock|timer   (default: managed — server-assigned /kiosk/managed)
+ *   gameId=<id>        with board|clock|timer only, open that game’s display route
  *   aptProxy=<url>     Apt-Cacher NG base URL (http://cache:3142); overrides POLODECK_PI_APT_PROXY
  *
  * Examples:

--- a/api/src/schemas/game.schemas.ts
+++ b/api/src/schemas/game.schemas.ts
@@ -110,6 +110,20 @@ export const eventLogRebuildBodySchema = z.object({
   events: z.array(eventLogRebuildRowSchema).min(1),
 });
 
+export const deviceCheckInBodySchema = z.object({
+  clientId: z.string().min(1),
+  name: z.string().optional(),
+});
+
+export const deviceIdParamSchema = z.object({
+  deviceId: z.string().cuid(),
+});
+
+export const patchDeviceBodySchema = z.object({
+  type: z.enum(["UNASSIGNED", "SCOREBOARD", "SHOT_CLOCK", "TIMER"]).optional(),
+  gameId: z.string().cuid().nullable().optional(),
+});
+
 export type CreateGameDayBody = z.infer<typeof createGameDayBodySchema>;
 export type UpdateGameDayBody = z.infer<typeof updateGameDayBodySchema>;
 export type GameDayIdParams = z.infer<typeof gameDayIdParamSchema>;
@@ -124,4 +138,6 @@ export type TriggerHornBody = z.infer<typeof triggerHornBodySchema>;
 export type ReplaceRosterBody = z.infer<typeof replaceRosterBodySchema>;
 export type ScoreCommandBody = z.infer<typeof scoreCommandBodySchema>;
 export type EventLogRebuildBody = z.infer<typeof eventLogRebuildBodySchema>;
+export type DeviceCheckInBody = z.infer<typeof deviceCheckInBodySchema>;
+export type PatchDeviceBody = z.infer<typeof patchDeviceBodySchema>;
 

--- a/api/src/services/deviceCapabilities.ts
+++ b/api/src/services/deviceCapabilities.ts
@@ -6,9 +6,13 @@ export type GameMode =
 export interface DeviceSummary {
   id: string;
   clientId: string;
-  type: "SCOREBOARD" | "SHOT_CLOCK" | "TIMER";
+  type: "UNASSIGNED" | "SCOREBOARD" | "SHOT_CLOCK" | "TIMER";
   name?: string | null;
+  gameId: string | null;
+  homeTeamName?: string | null;
+  awayTeamName?: string | null;
   lastCheckInAt: string;
+  updatedAt: string;
 }
 
 export interface DeviceCapabilities {
@@ -29,6 +33,7 @@ export function buildDeviceCapabilities(input: {
 }): DeviceCapabilities {
   const { now, devices, staleAfterMs } = input;
   const freshDevices = devices.filter((d) => {
+    if (d.type === "UNASSIGNED") return false;
     const last = new Date(d.lastCheckInAt).getTime();
     return now.getTime() - last <= staleAfterMs;
   });

--- a/api/src/services/game.service.ts
+++ b/api/src/services/game.service.ts
@@ -86,12 +86,32 @@ export class GameService {
     }
   }
 
-  async checkInDevice(input: {
+  private mapDeviceToSummary(d: {
+    id: string;
     clientId: string;
     type: DeviceType;
-    name?: string;
-  }) {
+    name: string | null;
+    gameId: string | null;
+    lastCheckInAt: Date;
+    updatedAt: Date;
+    game?: { homeTeamName: string; awayTeamName: string } | null;
+  }): DeviceSummary {
+    return {
+      id: d.id,
+      clientId: d.clientId,
+      type: d.type,
+      name: d.name,
+      gameId: d.gameId,
+      homeTeamName: d.game?.homeTeamName ?? null,
+      awayTeamName: d.game?.awayTeamName ?? null,
+      lastCheckInAt: d.lastCheckInAt.toISOString(),
+      updatedAt: d.updatedAt.toISOString(),
+    };
+  }
+
+  async checkInDevice(input: { clientId: string; name?: string }): Promise<DeviceSummary> {
     const now = new Date();
+    const gameInclude = { select: { homeTeamName: true, awayTeamName: true } as const };
 
     const existing = await this.prisma.device.findUnique({
       where: { clientId: input.clientId },
@@ -101,38 +121,73 @@ export class GameService {
       const updated = await this.prisma.device.update({
         where: { id: existing.id },
         data: {
-          type: input.type,
-          name: input.name,
+          ...(input.name !== undefined ? { name: input.name } : {}),
           lastCheckInAt: now,
         },
+        include: { game: gameInclude },
       });
-      return updated;
+      return this.mapDeviceToSummary(updated);
     }
 
     const created = await this.prisma.device.create({
       data: {
         clientId: input.clientId,
-        type: input.type,
+        type: DeviceType.UNASSIGNED,
         name: input.name,
         lastCheckInAt: now,
       },
+      include: { game: gameInclude },
     });
 
-    return created;
+    return this.mapDeviceToSummary(created);
+  }
+
+  async patchDevice(
+    deviceId: string,
+    input: { type?: DeviceType; gameId?: string | null }
+  ): Promise<DeviceSummary> {
+    const existing = await this.prisma.device.findUnique({ where: { id: deviceId } });
+    if (!existing) {
+      throw this.notFound("Device not found");
+    }
+
+    let nextType = input.type ?? existing.type;
+    let nextGameId = existing.gameId;
+
+    if (input.gameId !== undefined) {
+      nextGameId = input.gameId;
+    }
+
+    if (nextType === DeviceType.UNASSIGNED) {
+      nextGameId = null;
+    }
+
+    if (nextType !== DeviceType.UNASSIGNED) {
+      if (!nextGameId) {
+        throw this.badRequest("gameId is required for assigned display types");
+      }
+      const game = await this.prisma.game.findUnique({ where: { id: nextGameId } });
+      if (!game) {
+        throw this.badRequest("Game not found");
+      }
+    }
+
+    const updated = await this.prisma.device.update({
+      where: { id: deviceId },
+      data: { type: nextType, gameId: nextGameId },
+      include: { game: { select: { homeTeamName: true, awayTeamName: true } } },
+    });
+
+    return this.mapDeviceToSummary(updated);
   }
 
   async listAllDevices(): Promise<DeviceSummary[]> {
     const devices = await this.prisma.device.findMany({
       orderBy: { createdAt: "asc" },
+      include: { game: { select: { homeTeamName: true, awayTeamName: true } } },
     });
 
-    return devices.map((d: any) => ({
-      id: d.id,
-      clientId: d.clientId,
-      type: d.type,
-      name: d.name,
-      lastCheckInAt: d.lastCheckInAt.toISOString(),
-    }));
+    return devices.map((d) => this.mapDeviceToSummary(d));
   }
 
   async getGlobalDeviceCapabilities(): Promise<DeviceCapabilities> {

--- a/web-app/README.md
+++ b/web-app/README.md
@@ -1,6 +1,6 @@
 # PoloDeck web app
 
-Vite + React operator UI and **kiosk** routes under `/kiosk` (read-only scoreboard, shot clock, timer). Static Pi installer assets and the Phase 1 **setup screen** live in `public/kiosk/` (also copied from [`../pi/kiosk`](../pi/kiosk) during `npm run sync-kiosk` or the Docker build).
+Vite + React operator UI and **kiosk** routes under `/kiosk` (including **`/kiosk/managed`** for server-assigned Pis, plus per-game display URLs). Static Pi installer assets and the optional **setup screen** live in `public/kiosk/` (shell scripts are copied from [`../pi/kiosk`](../pi/kiosk) during `npm run sync-kiosk` or the Docker build).
 
 **Docker / production:** The image uses nginx. It serves the SPA and proxies **`/api/`** and **`/socket.io/`** to the `polodeck-api` service. Default build args use **`VITE_API_URL=/api`** and an empty **`VITE_SOCKET_URL`** so the browser uses the same origin as the page (port **8080** on the host).
 

--- a/web-app/index.html
+++ b/web-app/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700;800;900&display=swap"
+      rel="stylesheet"
+    />
     <title>PoloDeck — Game days</title>
   </head>
   <body>

--- a/web-app/public/kiosk/setup-screen.html
+++ b/web-app/public/kiosk/setup-screen.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>PoloDeck — Kiosk setup</title>
+    <title>PoloDeck kiosk registration</title>
     <style>
       :root {
         color-scheme: dark;
@@ -11,6 +11,7 @@
         --fg: #e8eef4;
         --muted: #8b9aab;
         --accent: #3d9cf0;
+        --warn: #f6c44f;
       }
       * {
         box-sizing: border-box;
@@ -54,22 +55,155 @@
         font-weight: 500;
         font-size: 0.95rem;
       }
+      .warn {
+        color: var(--warn);
+      }
       code {
         font-size: 0.9em;
         background: rgba(255, 255, 255, 0.06);
         padding: 0.15em 0.45em;
         border-radius: 0.25rem;
       }
+      .device {
+        margin-top: 1rem;
+      }
+      .device code {
+        font-size: 1.35rem;
+        letter-spacing: 0.08em;
+      }
+      .actions {
+        margin-top: 1rem;
+      }
+      .fallback-btn {
+        border: 1px solid rgba(61, 156, 240, 0.45);
+        background: rgba(61, 156, 240, 0.18);
+        color: var(--fg);
+        border-radius: 0.5rem;
+        padding: 0.55rem 0.9rem;
+        font-size: 0.95rem;
+        cursor: pointer;
+      }
+      .attempts {
+        margin-top: 0.75rem;
+        font-size: 0.9rem;
+        color: var(--muted);
+      }
     </style>
   </head>
   <body>
     <main>
-      <h1>PoloDeck kiosk is online</h1>
-      <p>
-        This Pi reached the PoloDeck web server and loaded the setup screen. Use the main web app to
-        pick games and open display links from <code>/kiosk</code>.
+      <h1 id="title">PoloDeck kiosk registration</h1>
+      <p id="body">
+        Checking server connectivity and registering this kiosk. Do not type on this device.
       </p>
-      <p class="ok" aria-live="polite">Network and kiosk path OK</p>
+      <p id="device" class="device" hidden>Device ID: <code id="device-code"></code></p>
+      <p id="status" class="ok" aria-live="polite">Connecting…</p>
+      <div id="actions" class="actions" hidden>
+        <button id="open-managed-btn" class="fallback-btn" type="button">
+          Open managed page
+        </button>
+      </div>
+      <p id="attempts" class="attempts" hidden></p>
     </main>
+    <script>
+      (function () {
+        const params = new URLSearchParams(window.location.search);
+        const managedMode = params.get("managed") === "1";
+        if (!managedMode) {
+          document.getElementById("title").textContent = "PoloDeck kiosk is online";
+          document.getElementById("body").innerHTML =
+            "This Pi reached the PoloDeck web server. Use <strong>Kiosks</strong> in the main app to assign role/game, or reinstall with default <code>/kb</code> to auto-register.";
+          document.getElementById("status").textContent = "Network and kiosk path OK";
+          return;
+        }
+
+        const storageKey = "polodeck-kiosk-client-id";
+        const statusEl = document.getElementById("status");
+        const bodyEl = document.getElementById("body");
+        const deviceWrap = document.getElementById("device");
+        const deviceCode = document.getElementById("device-code");
+        const actionsEl = document.getElementById("actions");
+        const attemptsEl = document.getElementById("attempts");
+        const openManagedBtn = document.getElementById("open-managed-btn");
+        const maxAutoRetriesBeforeButton = 10;
+        let failedAttempts = 0;
+
+        openManagedBtn.addEventListener("click", function () {
+          window.location.href = "/kiosk/managed";
+        });
+
+        function getOrCreateClientId() {
+          let id = localStorage.getItem(storageKey);
+          if (!id) {
+            id = (crypto && typeof crypto.randomUUID === "function")
+              ? crypto.randomUUID()
+              : "kiosk-" + Math.random().toString(36).slice(2, 12);
+            localStorage.setItem(storageKey, id);
+          }
+          return id;
+        }
+
+        function shortId(clientId) {
+          return clientId.replace(/-/g, "").slice(-8).toUpperCase();
+        }
+
+        function assignmentUrl(device) {
+          if (!device || !device.gameId || !device.type) return "";
+          if (device.type === "SCOREBOARD") return "/kiosk/g/" + device.gameId + "/display";
+          if (device.type === "SHOT_CLOCK") return "/kiosk/g/" + device.gameId + "/shot-clock";
+          if (device.type === "TIMER") return "/kiosk/g/" + device.gameId + "/timer";
+          return "";
+        }
+
+        async function checkInLoop() {
+          const clientId = getOrCreateClientId();
+          deviceWrap.hidden = false;
+          deviceCode.textContent = shortId(clientId);
+
+          let retryMs = 15000;
+          try {
+            const res = await fetch("/api/devices/check-in", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ clientId }),
+            });
+            if (!res.ok) throw new Error("HTTP " + res.status);
+            const json = await res.json();
+            const device = json && json.device ? json.device : null;
+            const target = assignmentUrl(device);
+            retryMs =
+              json && json.config && typeof json.config.heartbeatIntervalMs === "number"
+                ? json.config.heartbeatIntervalMs
+                : 15000;
+
+            if (target) {
+              statusEl.textContent = "Assigned. Opening display…";
+              window.location.replace(target);
+              return;
+            }
+            failedAttempts = 0;
+            actionsEl.hidden = true;
+            attemptsEl.hidden = true;
+            bodyEl.innerHTML =
+              "Connected to server. This kiosk is waiting for assignment in <strong>Kiosks</strong> in the main app.";
+            statusEl.textContent = "Registered and waiting for assignment";
+            statusEl.className = "ok";
+          } catch (_err) {
+            failedAttempts += 1;
+            statusEl.textContent = "Could not reach server. Retrying…";
+            statusEl.className = "ok warn";
+            attemptsEl.hidden = false;
+            attemptsEl.textContent = "Connection attempts failed: " + failedAttempts;
+            if (failedAttempts >= maxAutoRetriesBeforeButton) {
+              actionsEl.hidden = false;
+            }
+          }
+
+          window.setTimeout(checkInLoop, retryMs);
+        }
+
+        checkInLoop();
+      })();
+    </script>
   </body>
 </html>

--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -33,34 +33,207 @@
   min-width: 0;
 }
 
-.game-day-shell-help-btn {
+.game-day-shell-header-actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-top: 0.15rem;
+}
+
+.game-day-shell-icon-btn {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 2.5rem;
   height: 2.5rem;
-  margin-top: 0.15rem;
   padding: 0;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.22);
   background: rgba(255, 255, 255, 0.08);
   color: inherit;
   cursor: pointer;
+  text-decoration: none;
 }
 
-.game-day-shell-help-btn:hover {
+.game-day-shell-icon-btn:hover {
   background: rgba(255, 255, 255, 0.14);
 }
 
+.game-day-shell-icon-btn--active {
+  border-color: rgba(61, 156, 240, 0.55);
+  background: rgba(61, 156, 240, 0.12);
+}
+
 @media (prefers-color-scheme: light) {
-  .game-day-shell-help-btn {
+  .game-day-shell-icon-btn {
     border-color: rgba(0, 0, 0, 0.18);
     background: rgba(0, 0, 0, 0.05);
   }
 
-  .game-day-shell-help-btn:hover {
+  .game-day-shell-icon-btn:hover {
     background: rgba(0, 0, 0, 0.08);
+  }
+
+  .game-day-shell-icon-btn--active {
+    border-color: rgba(37, 99, 235, 0.45);
+    background: rgba(37, 99, 235, 0.08);
+  }
+}
+
+.kiosk-managed-waiting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  text-align: center;
+}
+
+.kiosk-managed-waiting-header {
+  max-width: 36rem;
+  padding: 1.5rem;
+}
+
+.kiosk-managed-waiting-title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.5rem, 4vw, 2rem);
+  font-weight: 600;
+}
+
+.kiosk-managed-waiting-sub {
+  margin: 0.5rem 0;
+  line-height: 1.55;
+  opacity: 0.85;
+}
+
+.kiosk-managed-device-id {
+  margin: 1.75rem 0 0;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.kiosk-managed-device-id-label {
+  display: block;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.7;
+  margin-bottom: 0.35rem;
+}
+
+.kiosk-managed-device-id-value {
+  font-size: clamp(2rem, 6vw, 3rem);
+  font-weight: 700;
+  font-family: ui-monospace, monospace;
+  letter-spacing: 0.08em;
+}
+
+.kiosk-managed-waiting-error {
+  margin-top: 1.25rem;
+  text-align: left;
+}
+
+@media (prefers-color-scheme: light) {
+  .kiosk-managed-device-id {
+    background: rgba(0, 0, 0, 0.04);
+    border-color: rgba(0, 0, 0, 0.1);
+  }
+}
+
+.kiosks-admin-page {
+  max-width: 64rem;
+}
+
+.kiosks-admin-header {
+  margin-bottom: 1.25rem;
+}
+
+.kiosks-admin-title {
+  margin: 0 0 0.35rem;
+  font-size: 1.35rem;
+}
+
+.kiosks-admin-sub {
+  margin: 0;
+  opacity: 0.85;
+  line-height: 1.5;
+}
+
+.kiosks-admin-code {
+  font-size: 0.9em;
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.kiosks-admin-meta {
+  font-size: 0.8rem;
+  opacity: 0.65;
+}
+
+.kiosks-admin-table-wrap {
+  overflow-x: auto;
+}
+
+.kiosks-admin-table {
+  width: 100%;
+  min-width: 640px;
+}
+
+.kiosks-admin-select {
+  min-width: 10rem;
+  max-width: 100%;
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+}
+
+.kiosks-admin-pill {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.kiosks-admin-pill--on {
+  background: rgba(34, 197, 94, 0.2);
+  color: rgb(34, 197, 94);
+}
+
+.kiosks-admin-pill--off {
+  background: rgba(248, 113, 113, 0.15);
+  color: rgb(248, 113, 113);
+}
+
+.kiosks-admin-row--stale {
+  opacity: 0.72;
+}
+
+.kiosks-admin-empty {
+  opacity: 0.85;
+}
+
+.kiosks-admin-banner-error {
+  color: rgb(248, 113, 113);
+  margin: 0 0 1rem;
+}
+
+@media (prefers-color-scheme: light) {
+  .kiosks-admin-code {
+    background: rgba(0, 0, 0, 0.06);
+  }
+
+  .kiosks-admin-pill--on {
+    background: rgba(22, 163, 74, 0.15);
+    color: rgb(22, 101, 52);
+  }
+
+  .kiosks-admin-pill--off {
+    background: rgba(220, 38, 38, 0.12);
+    color: rgb(185, 28, 28);
   }
 }
 

--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -2975,6 +2975,84 @@
   background: rgba(59, 130, 246, 0.15);
 }
 
+/* Stretch root chain — body flex row otherwise shrink-wraps #root to the left */
+body:has(.kiosk-scoreboard-display) {
+  display: block;
+  background: #000;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+body:has(.kiosk-scoreboard-display) #root,
+body:has(.kiosk-scoreboard-display) .app {
+  width: 100%;
+  min-height: 100vh;
+  min-height: 100dvh;
+  margin: 0;
+}
+
+/* Kiosk scoreboard display: upper-field layout, black field, red Orbitron scores */
+.kiosk-scoreboard-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: clamp(2rem, 10vh, 5rem) 1.25rem 2rem;
+  box-sizing: border-box;
+  text-align: center;
+  background: #000;
+  color: #f1f5f9;
+}
+
+.kiosk-scoreboard-display .kiosk-display-columns,
+.kiosk-scoreboard-display .kiosk-display-periods {
+  width: min(100%, 1200px);
+}
+
+.kiosk-scoreboard-display .kiosk-display-columns {
+  margin-bottom: 2.5rem;
+}
+
+.kiosk-scoreboard-display .kiosk-display-side {
+  padding: 1.75rem 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.kiosk-scoreboard-display .kiosk-display-team-label {
+  font-size: clamp(1rem, 2.2vw, 1.5rem);
+  margin-bottom: 0.5rem;
+}
+
+.kiosk-scoreboard-display .kiosk-display-team-name {
+  font-size: clamp(1.75rem, 4.5vw, 3rem);
+  margin-bottom: 1rem;
+}
+
+.kiosk-scoreboard-display .kiosk-phase {
+  font-size: clamp(1.15rem, 2.8vw, 1.75rem);
+  padding: 0.55rem 1rem;
+}
+
+.kiosk-scoreboard-display .kiosk-display-side--dark,
+.kiosk-scoreboard-display .kiosk-display-side--light {
+  background: #000;
+  color: #f1f5f9;
+}
+
+.kiosk-scoreboard-display .kiosk-display-score {
+  font-family: "Orbitron", ui-sans-serif, system-ui, sans-serif;
+  font-size: clamp(4.5rem, 20vw, 11rem);
+  font-weight: 900;
+  color: #ff1a1a;
+  letter-spacing: 0;
+  text-shadow: 0 0 12px rgba(255, 255, 255, 0.35);
+}
+
 .kiosk-shot-display {
   display: flex;
   flex-direction: column;

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -11,9 +11,11 @@ import { GameSheet } from "./pages/GameSheet";
 import { ScoreboardControl } from "./pages/ScoreboardControl";
 import { GameTimer } from "./pages/GameTimer";
 import { KioskHome } from "./pages/KioskHome";
+import { KioskManaged } from "./pages/KioskManaged";
 import { KioskScoreboardDisplay } from "./pages/KioskScoreboardDisplay";
 import { KioskShotClockDisplay } from "./pages/KioskShotClockDisplay";
 import { KioskTimerDisplay } from "./pages/KioskTimerDisplay";
+import { KiosksAdmin } from "./pages/KiosksAdmin";
 import "./App.css";
 
 function App() {
@@ -22,6 +24,7 @@ function App() {
       <div className="app">
         <Routes>
           <Route path="/kiosk" element={<KioskHome />} />
+          <Route path="/kiosk/managed" element={<KioskManaged />} />
           <Route path="/kiosk/g/:gameId/display" element={<KioskScoreboardDisplay />} />
           <Route path="/kiosk/g/:gameId/shot-clock" element={<KioskShotClockDisplay />} />
           <Route path="/kiosk/g/:gameId/timer" element={<KioskTimerDisplay />} />
@@ -36,6 +39,7 @@ function App() {
           <Route path="/" element={<GameDayShell />}>
             <Route index element={<GameDayHomeEmpty />} />
             <Route path="game-days/:id" element={<GameDayDetail />} />
+            <Route path="kiosks" element={<KiosksAdmin />} />
           </Route>
         </Routes>
       </div>

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -72,6 +72,25 @@ export interface DeviceCapabilities {
   mode: string;
 }
 
+export type KioskDeviceType = "UNASSIGNED" | "SCOREBOARD" | "SHOT_CLOCK" | "TIMER";
+
+export interface KioskDevice {
+  id: string;
+  clientId: string;
+  type: KioskDeviceType;
+  name: string | null;
+  gameId: string | null;
+  homeTeamName: string | null;
+  awayTeamName: string | null;
+  lastCheckInAt: string;
+  updatedAt: string;
+}
+
+export interface DeviceCheckInResponse {
+  device: KioskDevice;
+  config: { heartbeatIntervalMs: number; staleAfterMs: number };
+}
+
 export interface GameAggregate {
   id: string;
   gameDayId: string | null;
@@ -166,11 +185,14 @@ async function setPeriodFallback(id: string, targetPeriod: number): Promise<Game
 
 export const api = {
   devices: {
-    checkIn: (body: { clientId: string; type: string; name?: string }) =>
-      request<{ device: unknown; config: unknown }>("/devices/check-in", {
+    checkIn: (body: { clientId: string; name?: string }) =>
+      request<DeviceCheckInResponse>("/devices/check-in", {
         method: "POST",
         json: body,
       }),
+    list: () => request<KioskDevice[]>("/devices"),
+    update: (id: string, body: { type?: KioskDeviceType; gameId?: string | null }) =>
+      request<KioskDevice>(`/devices/${id}`, { method: "PATCH", json: body }),
   },
   capabilities: () =>
     request<DeviceCapabilities>("/capabilities"),

--- a/web-app/src/hooks/useKioskDeviceCheckIn.ts
+++ b/web-app/src/hooks/useKioskDeviceCheckIn.ts
@@ -3,7 +3,7 @@ import { api } from "../api/client";
 
 const STORAGE_KEY = "polodeck-kiosk-client-id";
 
-function getOrCreateClientId(): string {
+export function getOrCreateKioskClientId(): string {
   let id = localStorage.getItem(STORAGE_KEY);
   if (!id) {
     id = crypto.randomUUID();
@@ -12,13 +12,12 @@ function getOrCreateClientId(): string {
   return id;
 }
 
-export function useKioskDeviceCheckIn(type: "SCOREBOARD" | "SHOT_CLOCK" | "TIMER") {
+/** Heartbeat only; device role and game are assigned on the server (see /kiosk/managed). */
+export function useKioskDeviceCheckIn() {
   useEffect(() => {
-    const clientId = getOrCreateClientId();
-    void api.devices
-      .checkIn({ clientId, type, name: `kiosk-${type.toLowerCase()}` })
-      .catch(() => {
-        /* display still works without check-in */
-      });
-  }, [type]);
+    const clientId = getOrCreateKioskClientId();
+    void api.devices.checkIn({ clientId }).catch(() => {
+      /* display still works without check-in */
+    });
+  }, []);
 }

--- a/web-app/src/pages/GameDayShell.tsx
+++ b/web-app/src/pages/GameDayShell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { MessageCircleQuestionMark } from "lucide-react";
+import { MessageCircleQuestionMark, Monitor } from "lucide-react";
 import { NavLink, Outlet } from "react-router-dom";
 import { api, type DeviceCapabilities } from "../api/client";
 import type { GameDay } from "../types/gameDay";
@@ -122,15 +122,27 @@ export function GameDayShell() {
             </span>
           </div>
         </div>
-        <button
-          type="button"
-          className="game-day-shell-help-btn"
-          onClick={() => setGuideOpen(true)}
-          aria-label="Open user guide"
-          title="User guide"
-        >
-          <MessageCircleQuestionMark size={22} strokeWidth={2} aria-hidden />
-        </button>
+        <div className="game-day-shell-header-actions">
+          <NavLink
+            to="/kiosks"
+            className={({ isActive }) =>
+              `game-day-shell-icon-btn${isActive ? " game-day-shell-icon-btn--active" : ""}`
+            }
+            aria-label="Kiosks"
+            title="Kiosks"
+          >
+            <Monitor size={22} strokeWidth={2} aria-hidden />
+          </NavLink>
+          <button
+            type="button"
+            className="game-day-shell-icon-btn"
+            onClick={() => setGuideOpen(true)}
+            aria-label="Open user guide"
+            title="User guide"
+          >
+            <MessageCircleQuestionMark size={22} strokeWidth={2} aria-hidden />
+          </button>
+        </div>
       </header>
 
       <div className="game-day-shell-layout">
@@ -202,8 +214,8 @@ export function GameDayShell() {
                 Use <strong>Roster</strong> on each game to enter or import player names by cap number.
               </li>
               <li>
-                Connect <strong>scoreboard</strong>, <strong>timer</strong>, and <strong>shot clock</strong> clients to
-                the server; status appears above.
+                Open <strong>Kiosks</strong> (monitor icon) to assign Raspberry Pi displays; connection status
+                appears above.
               </li>
             </ul>
           </div>

--- a/web-app/src/pages/KioskHome.tsx
+++ b/web-app/src/pages/KioskHome.tsx
@@ -49,10 +49,14 @@ export function KioskHome() {
     <div className="page kiosk-home-page">
       <header className="kiosk-home-header">
         <h1>PoloDeck kiosk</h1>
-        <p className="kiosk-home-sub">Open a display link on each Pi (fullscreen, read-only).</p>
+        <p className="kiosk-home-sub">
+          New Pis: run the installer below, then assign each device under <strong>Kiosks</strong> in the main app.
+          Legacy links below open a fixed game URL without server assignment.
+        </p>
         <p className="kiosk-home-install">
           Install a Pi with:{" "}
-          <code className="kiosk-home-code">{`curl -fsSL 'http://<LAN-IP>:3000/kb' | sudo bash`}</code>
+          <code className="kiosk-home-code">{`curl -fsSL 'http://<LAN-IP>:3000/kb' | sudo bash`}</code>{" "}
+          (opens <code className="kiosk-home-code">/kiosk/managed</code>)
         </p>
       </header>
       {games.length === 0 ? (

--- a/web-app/src/pages/KioskManaged.tsx
+++ b/web-app/src/pages/KioskManaged.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { api, type KioskDevice } from "../api/client";
+import { ApiErrorDisplay } from "../components/DatabaseUnavailable";
+import { getOrCreateKioskClientId } from "../hooks/useKioskDeviceCheckIn";
+import { KioskScoreboardDisplay } from "./KioskScoreboardDisplay";
+import { KioskShotClockDisplay } from "./KioskShotClockDisplay";
+import { KioskTimerDisplay } from "./KioskTimerDisplay";
+
+function shortDeviceLabel(clientId: string): string {
+  const compact = clientId.replace(/-/g, "");
+  return compact.slice(-8).toUpperCase();
+}
+
+function isReadyForDisplay(d: KioskDevice): boolean {
+  if (d.type === "UNASSIGNED") return false;
+  return Boolean(d.gameId);
+}
+
+export function KioskManaged() {
+  const [device, setDevice] = useState<KioskDevice | null>(null);
+  const [error, setError] = useState<unknown>(null);
+
+  useEffect(() => {
+    const clientId = getOrCreateKioskClientId();
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const loop = async () => {
+      if (cancelled) return;
+      let nextMs = 15_000;
+      try {
+        const res = await api.devices.checkIn({ clientId });
+        if (cancelled) return;
+        setDevice(res.device);
+        setError(null);
+        nextMs = res.config.heartbeatIntervalMs;
+      } catch (e) {
+        if (!cancelled) setError(e);
+      }
+      if (cancelled) return;
+      timeoutId = window.setTimeout(loop, nextMs);
+    };
+
+    void loop();
+
+    return () => {
+      cancelled = true;
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+    };
+  }, []);
+
+  if (error && !device) {
+    return (
+      <div className="page kiosk-display-page kiosk-managed-waiting">
+        <ApiErrorDisplay error={error} />
+      </div>
+    );
+  }
+
+  if (device && isReadyForDisplay(device) && device.gameId) {
+    const gid = device.gameId;
+    if (device.type === "SCOREBOARD") {
+      return <KioskScoreboardDisplay gameId={gid} />;
+    }
+    if (device.type === "SHOT_CLOCK") {
+      return <KioskShotClockDisplay gameId={gid} />;
+    }
+    if (device.type === "TIMER") {
+      return <KioskTimerDisplay gameId={gid} />;
+    }
+  }
+
+  const label = device ? shortDeviceLabel(device.clientId) : "…";
+
+  return (
+    <div className="page kiosk-display-page kiosk-managed-waiting">
+      <header className="kiosk-managed-waiting-header">
+        <h1 className="kiosk-managed-waiting-title">Waiting for assignment</h1>
+        <p className="kiosk-managed-waiting-sub">
+          This kiosk is connected. In the main PoloDeck app, open <strong>Kiosks</strong> (monitor icon
+          in the header) and assign a role and game for this device.
+        </p>
+        <p className="kiosk-managed-device-id" aria-label="Device identifier for matching in admin">
+          <span className="kiosk-managed-device-id-label">Device ID</span>
+          <span className="kiosk-managed-device-id-value">{label}</span>
+        </p>
+        {error ? (
+          <div className="kiosk-managed-waiting-error">
+            <ApiErrorDisplay error={error} />
+          </div>
+        ) : null}
+      </header>
+    </div>
+  );
+}

--- a/web-app/src/pages/KioskScoreboardDisplay.tsx
+++ b/web-app/src/pages/KioskScoreboardDisplay.tsx
@@ -6,12 +6,18 @@ import { ApiErrorDisplay } from "../components/DatabaseUnavailable";
 import { useKioskDeviceCheckIn } from "../hooks/useKioskDeviceCheckIn";
 import { createGameSocket } from "../lib/socketUrl";
 
-export function KioskScoreboardDisplay() {
-  const { gameId } = useParams<{ gameId: string }>();
+type KioskScoreboardDisplayProps = {
+  /** When set (e.g. server-managed kiosk), overrides `useParams` game id. */
+  gameId?: string;
+};
+
+export function KioskScoreboardDisplay(props: KioskScoreboardDisplayProps) {
+  const { gameId: routeGameId } = useParams<{ gameId: string }>();
+  const gameId = props.gameId ?? routeGameId;
   const [aggregate, setAggregate] = useState<GameAggregate | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
-  useKioskDeviceCheckIn("SCOREBOARD");
+  useKioskDeviceCheckIn();
 
   useEffect(() => {
     if (!gameId) return;

--- a/web-app/src/pages/KioskScoreboardDisplay.tsx
+++ b/web-app/src/pages/KioskScoreboardDisplay.tsx
@@ -49,21 +49,21 @@ export function KioskScoreboardDisplay(props: KioskScoreboardDisplayProps) {
 
   if (loading) {
     return (
-      <div className="page kiosk-display-page">
+      <div className="kiosk-display-page kiosk-scoreboard-display">
         <p>Loading…</p>
       </div>
     );
   }
   if (error && !aggregate) {
     return (
-      <div className="page kiosk-display-page">
+      <div className="kiosk-display-page kiosk-scoreboard-display">
         <ApiErrorDisplay error={error} />
       </div>
     );
   }
   if (!gameId || !aggregate) {
     return (
-      <div className="page kiosk-display-page">
+      <div className="kiosk-display-page kiosk-scoreboard-display">
         <p>Game not found.</p>
       </div>
     );
@@ -75,32 +75,36 @@ export function KioskScoreboardDisplay(props: KioskScoreboardDisplayProps) {
   const cp = aggregate.currentPeriod;
   const isFinal = aggregate.status === "FINAL";
 
+  const inP3 = !isFinal && cp === 3;
+  const halftimeMs = aggregate.halftimeDurationMs ?? 5 * 60 * 1000;
+  const clockDur = aggregate.gameClock?.durationMs;
+  const halfTimeActive =
+    inP3 && clockDur != null && Math.abs(clockDur - halftimeMs) < 500;
+  const q3Active = inP3 && !halfTimeActive;
+
   const phaseActive = {
     q1: !isFinal && cp === 1,
     q2: !isFinal && cp === 2,
-    q3: !isFinal && cp === 3,
+    ht: halfTimeActive,
+    q3: q3Active,
     q4: !isFinal && cp === 4 && tp >= 4,
     ot: !isFinal && cp === 5 && tp >= 5,
     final: isFinal,
   };
 
   return (
-    <div className="page kiosk-display-page kiosk-scoreboard-display">
-      <header className="kiosk-display-header">
-        <h1 className="kiosk-display-title">
-          {aggregate.homeTeamName} vs {aggregate.awayTeamName}
-        </h1>
-        <p className="kiosk-display-meta">Scoreboard · Period {cp} of {tp}</p>
-      </header>
-
+    <div
+      className="kiosk-display-page kiosk-scoreboard-display"
+      aria-label={`${aggregate.homeTeamName} vs ${aggregate.awayTeamName}, period ${cp} of ${tp}`}
+    >
       <div className="kiosk-display-columns">
         <section className="kiosk-display-side kiosk-display-side--dark" aria-label="Home">
           <div className="kiosk-display-team-label">Home · Dark</div>
           <div className="kiosk-display-team-name">{aggregate.homeTeamName}</div>
           <div className="kiosk-display-score">{homeScore}</div>
         </section>
-        <section className="kiosk-display-side kiosk-display-side--light" aria-label="Away">
-          <div className="kiosk-display-team-label">Away · Light</div>
+        <section className="kiosk-display-side kiosk-display-side--light" aria-label="Guest">
+          <div className="kiosk-display-team-label">Guest · Light</div>
           <div className="kiosk-display-team-name">{aggregate.awayTeamName}</div>
           <div className="kiosk-display-score">{awayScore}</div>
         </section>
@@ -110,7 +114,8 @@ export function KioskScoreboardDisplay(props: KioskScoreboardDisplayProps) {
         <div className="kiosk-display-period-row">
           <span className={`kiosk-phase${phaseActive.q1 ? " is-active" : ""}`}>Q1</span>
           <span className={`kiosk-phase${phaseActive.q2 ? " is-active" : ""}`}>Q2</span>
-          <span className={`kiosk-phase${phaseActive.q3 ? " is-active" : ""}`}>Q3 / HT</span>
+          <span className={`kiosk-phase${phaseActive.ht ? " is-active" : ""}`}>HT</span>
+          <span className={`kiosk-phase${phaseActive.q3 ? " is-active" : ""}`}>Q3</span>
           <span className={`kiosk-phase${phaseActive.q4 ? " is-active" : ""}`}>Q4</span>
           <span className={`kiosk-phase${phaseActive.ot ? " is-active" : ""}`}>OT</span>
           <span className={`kiosk-phase${phaseActive.final ? " is-active" : ""}`}>Final</span>

--- a/web-app/src/pages/KioskShotClockDisplay.tsx
+++ b/web-app/src/pages/KioskShotClockDisplay.tsx
@@ -10,13 +10,18 @@ import {
 } from "../lib/clockDisplay";
 import { createGameSocket } from "../lib/socketUrl";
 
-export function KioskShotClockDisplay() {
-  const { gameId } = useParams<{ gameId: string }>();
+type KioskShotClockDisplayProps = {
+  gameId?: string;
+};
+
+export function KioskShotClockDisplay(props: KioskShotClockDisplayProps) {
+  const { gameId: routeGameId } = useParams<{ gameId: string }>();
+  const gameId = props.gameId ?? routeGameId;
   const [aggregate, setAggregate] = useState<GameAggregate | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
   const [now, setNow] = useState(() => Date.now());
-  useKioskDeviceCheckIn("SHOT_CLOCK");
+  useKioskDeviceCheckIn();
 
   useEffect(() => {
     if (!gameId) return;

--- a/web-app/src/pages/KioskTimerDisplay.tsx
+++ b/web-app/src/pages/KioskTimerDisplay.tsx
@@ -11,13 +11,18 @@ import {
 } from "../lib/clockDisplay";
 import { createGameSocket } from "../lib/socketUrl";
 
-export function KioskTimerDisplay() {
-  const { gameId } = useParams<{ gameId: string }>();
+type KioskTimerDisplayProps = {
+  gameId?: string;
+};
+
+export function KioskTimerDisplay(props: KioskTimerDisplayProps) {
+  const { gameId: routeGameId } = useParams<{ gameId: string }>();
+  const gameId = props.gameId ?? routeGameId;
   const [aggregate, setAggregate] = useState<GameAggregate | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
   const [now, setNow] = useState(() => Date.now());
-  useKioskDeviceCheckIn("TIMER");
+  useKioskDeviceCheckIn();
 
   useEffect(() => {
     if (!gameId) return;

--- a/web-app/src/pages/KiosksAdmin.tsx
+++ b/web-app/src/pages/KiosksAdmin.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, ApiError, type KioskDevice, type KioskDeviceType } from "../api/client";
+import { ApiErrorDisplay } from "../components/DatabaseUnavailable";
+
+const STALE_AFTER_MS = 180_000;
+
+const DEVICE_TYPES: { value: KioskDeviceType; label: string }[] = [
+  { value: "UNASSIGNED", label: "Unassigned" },
+  { value: "SCOREBOARD", label: "Scoreboard" },
+  { value: "SHOT_CLOCK", label: "Shot clock" },
+  { value: "TIMER", label: "Timer" },
+];
+
+function isStale(lastCheckInAt: string): boolean {
+  return Date.now() - new Date(lastCheckInAt).getTime() > STALE_AFTER_MS;
+}
+
+export function KiosksAdmin() {
+  const [devices, setDevices] = useState<KioskDevice[]>([]);
+  const [games, setGames] = useState<{ id: string; homeTeamName: string; awayTeamName: string }[]>(
+    []
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    const [devList, gameList] = await Promise.all([api.devices.list(), api.games.list()]);
+    setDevices(devList);
+    setGames(gameList);
+  }, []);
+
+  useEffect(() => {
+    load()
+      .catch((e) => setError(e))
+      .finally(() => setLoading(false));
+  }, [load]);
+
+  const onSave = async (device: KioskDevice, type: KioskDeviceType, gameId: string) => {
+    setSavingId(device.id);
+    setRowError(null);
+    try {
+      if (type === "UNASSIGNED") {
+        await api.devices.update(device.id, { type: "UNASSIGNED", gameId: null });
+      } else {
+        if (!gameId) {
+          setRowError("Choose a game for this role.");
+          return;
+        }
+        await api.devices.update(device.id, { type, gameId });
+      }
+      await load();
+    } catch (e) {
+      setRowError(e instanceof ApiError ? e.message : e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="page kiosks-admin-page">
+        <p>Loading kiosks…</p>
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="page kiosks-admin-page">
+        <ApiErrorDisplay error={error} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="page kiosks-admin-page">
+      <header className="kiosks-admin-header">
+        <h1 className="kiosks-admin-title">Kiosks</h1>
+        <p className="kiosks-admin-sub">
+          Devices appear here after they open <code className="kiosks-admin-code">/kiosk/managed</code>. Assign
+          a display role and game for each Pi; no typing is required on the device.
+        </p>
+      </header>
+
+      {rowError ? <p className="kiosks-admin-banner-error">{rowError}</p> : null}
+
+      {devices.length === 0 ? (
+        <p className="kiosks-admin-empty">No kiosks yet. Boot a Pi with the PoloDeck installer URL.</p>
+      ) : (
+        <div className="kiosks-admin-table-wrap">
+          <table className="table kiosks-admin-table">
+            <thead>
+              <tr>
+                <th>Status</th>
+                <th>Device ID (match on screen)</th>
+                <th>Role</th>
+                <th>Game</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {devices.map((d) => (
+                <KioskDeviceRow
+                  key={d.id}
+                  device={d}
+                  games={games}
+                  saving={savingId === d.id}
+                  onSave={onSave}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function KioskDeviceRow({
+  device: d,
+  games,
+  saving,
+  onSave,
+}: {
+  device: KioskDevice;
+  games: { id: string; homeTeamName: string; awayTeamName: string }[];
+  saving: boolean;
+  onSave: (device: KioskDevice, type: KioskDeviceType, gameId: string) => void;
+}) {
+  const [type, setType] = useState<KioskDeviceType>(d.type);
+  const [gameId, setGameId] = useState(d.gameId ?? "");
+
+  /* eslint-disable react-hooks/set-state-in-effect -- sync selects when server row changes */
+  useEffect(() => {
+    setType(d.type);
+    setGameId(d.gameId ?? "");
+  }, [d.type, d.gameId]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const stale = isStale(d.lastCheckInAt);
+  const shortLabel = d.clientId.replace(/-/g, "").slice(-8).toUpperCase();
+
+  return (
+    <tr className={stale ? "kiosks-admin-row--stale" : undefined}>
+      <td>
+        <span className={`kiosks-admin-pill ${stale ? "kiosks-admin-pill--off" : "kiosks-admin-pill--on"}`}>
+          {stale ? "Offline" : "Online"}
+        </span>
+      </td>
+      <td>
+        <code className="kiosks-admin-code">{shortLabel}</code>
+        <span className="kiosks-admin-meta"> · full id in tools if needed</span>
+      </td>
+      <td>
+        <select
+          className="kiosks-admin-select"
+          value={type}
+          onChange={(e) => setType(e.target.value as KioskDeviceType)}
+          aria-label="Kiosk role"
+        >
+          {DEVICE_TYPES.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td>
+        <select
+          className="kiosks-admin-select"
+          value={gameId}
+          onChange={(e) => setGameId(e.target.value)}
+          disabled={type === "UNASSIGNED"}
+          aria-label="Game"
+        >
+          <option value="">—</option>
+          {games.map((g) => (
+            <option key={g.id} value={g.id}>
+              {g.homeTeamName} vs {g.awayTeamName}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td>
+        <button
+          type="button"
+          className="btn btn-compact primary"
+          disabled={saving}
+          onClick={() => onSave(d, type, gameId)}
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
This branch delivers server-managed Raspberry Pi kiosks and a v1 fullscreen scoreboard. Pis installed via /kb default to managed mode: they register with a stable client ID, show a short device ID for matching, and poll until an operator assigns role and game in the new Kiosks admin screen. The API adds UNASSIGNED devices, gameId, and PATCH /devices/:id; check-in no longer requires type at boot. /kiosk/managed heartbeats and routes to scoreboard, shot clock, or timer when assigned. Legacy fixed-game kiosk URLs remain. The scoreboard is restyled for venue TVs: black field, large red Orbitron scores, separate HT/Q3 indicators, and full-viewport layout.

<img width="1456" height="754" alt="image" src="https://github.com/user-attachments/assets/9259a58c-66e1-44f5-b76a-b4d66e50d205" />
