### PR TITLE
57 rm shot clock events

### DIFF
--- a/api/src/services/game.service.ts
+++ b/api/src/services/game.service.ts
@@ -47,6 +47,37 @@ export class GameService {
     return aggregate;
   }
 
+  /** True if this period already has a GAME_CLOCK_STARTED (clock resume should not add another). */
+  private async quarterStartAlreadyLogged(gameId: string): Promise<boolean> {
+    const lastPeriodAdvance = await this.prisma.gameEvent.findFirst({
+      where: { gameId, eventType: GameEventType.PERIOD_ADVANCED },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      select: { createdAt: true, id: true },
+    });
+
+    const afterPeriod: Prisma.GameEventWhereInput = lastPeriodAdvance
+      ? {
+          OR: [
+            { createdAt: { gt: lastPeriodAdvance.createdAt } },
+            {
+              createdAt: lastPeriodAdvance.createdAt,
+              id: { gt: lastPeriodAdvance.id },
+            },
+          ],
+        }
+      : {};
+
+    const existing = await this.prisma.gameEvent.findFirst({
+      where: {
+        gameId,
+        eventType: GameEventType.GAME_CLOCK_STARTED,
+        ...afterPeriod,
+      },
+      select: { id: true },
+    });
+    return existing != null;
+  }
+
   private async createEvent(
     gameId: string,
     eventType: GameEventType,
@@ -714,6 +745,14 @@ export class GameService {
   }
 
   async startGameClock(gameId: string) {
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      select: { currentPeriod: true },
+    });
+    if (!game) {
+      throw this.notFound("Game not found");
+    }
+
     const clock = await this.prisma.gameClock.findUnique({
       where: { gameId },
     });
@@ -740,7 +779,14 @@ export class GameService {
       },
     });
 
-    await this.createEvent(gameId, GameEventType.GAME_CLOCK_STARTED, {}, "operator");
+    if (!(await this.quarterStartAlreadyLogged(gameId))) {
+      await this.createEvent(
+        gameId,
+        GameEventType.GAME_CLOCK_STARTED,
+        { period: game.currentPeriod },
+        "operator"
+      );
+    }
     // Always resync the shot: materialize then start (repairs "running" without lastStartedAt, or
     // a stale pre-coupling shot-while-game-stopped state).
     await this.resyncShotClockWithGameStart(gameId);

--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -818,10 +818,38 @@
 
 .scoreboard-footer {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
-  gap: 2rem;
+  align-items: baseline;
+  gap: 0.75rem 1.5rem;
   font-size: 0.85rem;
   opacity: 0.9;
+}
+
+.scoreboard-footer-clocks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.25rem;
+}
+
+.scoreboard-clock {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.scoreboard-clock-label {
+  opacity: 0.85;
+}
+
+.scoreboard-clock-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  min-width: 2.5ch;
+}
+
+.scoreboard-clock--running .scoreboard-clock-value {
+  color: var(--color-primary, #6b8cff);
 }
 
 .game-sheet-rosters {

--- a/web-app/src/lib/gameProgressDisplay.ts
+++ b/web-app/src/lib/gameProgressDisplay.ts
@@ -1,0 +1,14 @@
+/** Operational clock events hidden from the game sheet progress table. */
+export const GAME_PROGRESS_HIDDEN_EVENT_TYPES = new Set<string>([
+  "GAME_CLOCK_STOPPED",
+  "GAME_CLOCK_SET",
+  "SHOT_CLOCK_STARTED",
+  "SHOT_CLOCK_STOPPED",
+  "SHOT_CLOCK_RESET",
+  "SHOT_CLOCK_RESET_UNDONE",
+  "SHOT_CLOCK_SET",
+]);
+
+export function isGameProgressRowHidden(eventType: string): boolean {
+  return GAME_PROGRESS_HIDDEN_EVENT_TYPES.has(eventType);
+}

--- a/web-app/src/lib/gameProgressDisplay.ts
+++ b/web-app/src/lib/gameProgressDisplay.ts
@@ -12,3 +12,41 @@ export const GAME_PROGRESS_HIDDEN_EVENT_TYPES = new Set<string>([
 export function isGameProgressRowHidden(eventType: string): boolean {
   return GAME_PROGRESS_HIDDEN_EVENT_TYPES.has(eventType);
 }
+
+type ProgressEvent = { eventType: string; payload?: unknown };
+
+/**
+ * One "Quarter started" per period: keep the first GAME_CLOCK_STARTED after each
+ * PERIOD_ADVANCED (or for Q1 before any advance). Later clock resumes in the same
+ * period are omitted from the table.
+ */
+export function eventsForGameProgressDisplay<T extends ProgressEvent>(events: T[]): T[] {
+  let seenQuarterStartForPeriod = false;
+  const out: T[] = [];
+
+  for (const ev of events) {
+    if (ev.eventType === "PERIOD_ADVANCED") {
+      seenQuarterStartForPeriod = false;
+      if (!isGameProgressRowHidden(ev.eventType)) {
+        out.push(ev);
+      }
+      continue;
+    }
+
+    if (ev.eventType === "GAME_CLOCK_STARTED") {
+      if (!seenQuarterStartForPeriod) {
+        seenQuarterStartForPeriod = true;
+        if (!isGameProgressRowHidden(ev.eventType)) {
+          out.push(ev);
+        }
+      }
+      continue;
+    }
+
+    if (!isGameProgressRowHidden(ev.eventType)) {
+      out.push(ev);
+    }
+  }
+
+  return out;
+}

--- a/web-app/src/pages/GameSheet.tsx
+++ b/web-app/src/pages/GameSheet.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import type { Socket } from "socket.io-client";
-import { isGameProgressRowHidden } from "../lib/gameProgressDisplay";
+import {
+  formatGameTimeDisplay,
+  formatShotClockDisplay,
+  getEffectiveRemainingMs,
+  isHalftimeActive,
+} from "../lib/clockDisplay";
+import { eventsForGameProgressDisplay } from "../lib/gameProgressDisplay";
 import { createGameSocket } from "../lib/socketUrl";
 import { api, type GameAggregate } from "../api/client";
 import { ApiErrorDisplay } from "../components/DatabaseUnavailable";
@@ -106,7 +112,17 @@ export function GameSheet() {
   const [exTime, setExTime] = useState("");
   const [toSide, setToSide] = useState<TeamSide>("HOME");
   const [toShort, setToShort] = useState(false);
+  const [tick, setTick] = useState(0);
   const navigate = useNavigate();
+
+  const gameRunning = aggregate?.gameClock?.running ?? false;
+  const shotRunning = aggregate?.shotClock?.running ?? false;
+
+  useEffect(() => {
+    if (!gameRunning && !shotRunning) return;
+    const id = window.setInterval(() => setTick((n) => n + 1), 100);
+    return () => window.clearInterval(id);
+  }, [gameRunning, shotRunning]);
 
   useEffect(() => {
     if (!commandHelpOpen) return;
@@ -407,17 +423,9 @@ export function GameSheet() {
     return [arr[0] ?? "—", arr[1] ?? "—", arr[2] ?? "—"];
   };
 
-  const formatMsToClock = (ms: number | null | undefined) => {
-    if (ms == null) return "—";
-    const totalSeconds = Math.floor(ms / 1000);
-    const m = Math.floor(totalSeconds / 60);
-    const s = totalSeconds % 60;
-    return `${m}:${s.toString().padStart(2, "0")}`;
-  };
-
-  const progressRows = (Array.isArray(aggregate.events) ? aggregate.events : [])
-    .filter((ev) => !isGameProgressRowHidden(ev.eventType))
-    .map((ev) => {
+  const progressRows = eventsForGameProgressDisplay(
+    Array.isArray(aggregate.events) ? aggregate.events : []
+  ).map((ev) => {
     const p = ev.payload as Record<string, unknown> | undefined;
     const side = (p?.side ?? p?.teamSide) as string | undefined;
     const team = side === "HOME" ? "Dark" : side === "AWAY" ? "Light" : "—";
@@ -783,6 +791,16 @@ export function GameSheet() {
     .filter((s): s is string => typeof s === "string" && s.trim().length > 0)
     .join(" ");
 
+  void tick;
+  const now = Date.now();
+  const halftimeActive = isHalftimeActive(aggregate);
+  const gameClockDisplay = aggregate.gameClock
+    ? formatGameTimeDisplay(getEffectiveRemainingMs(aggregate.gameClock, now))
+    : "—";
+  const shotClockDisplay = aggregate.shotClock
+    ? formatShotClockDisplay(getEffectiveRemainingMs(aggregate.shotClock, now))
+    : "—";
+
   return (
     <div className="page game-sheet-page">
       <header className="page-header game-sheet-page-header">
@@ -871,8 +889,32 @@ export function GameSheet() {
                 </div>
               </div>
               <div className="scoreboard-footer">
-                <div>Period: Q{aggregate.currentPeriod}</div>
-                <div>Game clock: {aggregate.gameClock?.running ? formatMsToClock(aggregate.gameClock.remainingMs) : "—"}</div>
+                <div className="scoreboard-footer-period">
+                  Period: Q{aggregate.currentPeriod}
+                  {halftimeActive ? " · HT" : null}
+                </div>
+                <div className="scoreboard-footer-clocks" aria-live="polite">
+                  <div
+                    className={
+                      gameRunning
+                        ? "scoreboard-clock scoreboard-clock--running"
+                        : "scoreboard-clock"
+                    }
+                  >
+                    <span className="scoreboard-clock-label">Game</span>
+                    <span className="scoreboard-clock-value">{gameClockDisplay}</span>
+                  </div>
+                  <div
+                    className={
+                      shotRunning
+                        ? "scoreboard-clock scoreboard-clock--running"
+                        : "scoreboard-clock"
+                    }
+                  >
+                    <span className="scoreboard-clock-label">Shot</span>
+                    <span className="scoreboard-clock-value">{shotClockDisplay}</span>
+                  </div>
+                </div>
               </div>
             </div>
           </section>

--- a/web-app/src/pages/GameSheet.tsx
+++ b/web-app/src/pages/GameSheet.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import type { Socket } from "socket.io-client";
+import { isGameProgressRowHidden } from "../lib/gameProgressDisplay";
 import { createGameSocket } from "../lib/socketUrl";
 import { api, type GameAggregate } from "../api/client";
 import { ApiErrorDisplay } from "../components/DatabaseUnavailable";
@@ -415,7 +416,7 @@ export function GameSheet() {
   };
 
   const progressRows = (Array.isArray(aggregate.events) ? aggregate.events : [])
-    .filter((ev) => ev.eventType !== "GAME_CLOCK_STOPPED")
+    .filter((ev) => !isGameProgressRowHidden(ev.eventType))
     .map((ev) => {
     const p = ev.payload as Record<string, unknown> | undefined;
     const side = (p?.side ?? p?.teamSide) as string | undefined;
@@ -459,9 +460,6 @@ export function GameSheet() {
         break;
       case "GAME_CLOCK_STARTED":
         remark = "Quarter started";
-        break;
-      case "GAME_CLOCK_SET":
-        remark = "Clock set";
         break;
       case "HORN_TRIGGERED":
         remark = "Horn";


### PR DESCRIPTION
# Branch `57-rm-shot-clock-events`

Cleaner game sheet progress log and scoreboard clocks after shot-clock integration.

## Changes

### Hide Operational Clock Noise
- Centralizes filtered event types in `gameProgressDisplay.ts`:
  - `GAME_CLOCK_STARTED`
  - `GAME_CLOCK_STOPPED`
  - `GAME_CLOCK_SET`
  - `GAME_CLOCK_RESET`
  - `SHOT_CLOCK_STARTED`
  - `SHOT_CLOCK_STOPPED`
  - `SHOT_CLOCK_SET`
  - `SHOT_CLOCK_RESET`
- Keeps the progress table focused on:
  - Scoring
  - Fouls
  - Timeouts
  - Period changes

### One "Quarter Started" Per Period
- Client-side `eventsForGameProgressDisplay()` now keeps only the first `GAME_CLOCK_STARTED` event:
  - After each `PERIOD_ADVANCED`
  - Or in Q1 before any period advancement
- Prevents duplicate "Quarter started" entries when the game clock is paused and resumed.

### API Alignment (Local, Uncommitted)
- `startGameClock()` logs `GAME_CLOCK_STARTED` only when the current period has not already recorded a quarter start.
- Includes the current period in the event payload.
- Behavior now matches the UI deduplication logic.

### Scoreboard Footer
- Added live game clock and shot clock displays.
- Uses shared `clockDisplay` helpers:
  - Effective remaining time calculation
  - 100ms refresh while clocks are running
- Displays `HT` during halftime when applicable.
- Includes running-clock visual styling.

## Removed
- Standalone **"Clock set"** progress remark.
- Inline `formatMsToClock()` usage on the game sheet in favor of shared formatting helpers.

<img width="376" height="500" alt="image" src="https://github.com/user-attachments/assets/57f42fd3-73e8-458d-8cfd-64a077c2b60e" />
