### PR TITLE
Added remove game

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -201,6 +201,9 @@ curl -X POST http://localhost:3000/api/games \
   - active exclusions
   - recent events
 
+- **DELETE** `/api/games/:id`
+  Permanently delete a game and all related data (score, clocks, events, roster, etc.). Returns `204` with no body.
+
 ---
 
 ### Score Commands

--- a/api/src/routes/games.ts
+++ b/api/src/routes/games.ts
@@ -69,6 +69,12 @@ export async function registerGameRoutes(app: FastifyInstance) {
     return service.updateGame(params.id, body);
   });
 
+  app.delete("/games/:id", async (request, reply) => {
+    const params = gameIdParamSchema.parse(request.params);
+    await service.deleteGame(params.id);
+    reply.code(204);
+  });
+
   app.get("/games", async () => {
     return service.listGames();
   });

--- a/api/src/services/game.service.ts
+++ b/api/src/services/game.service.ts
@@ -284,6 +284,14 @@ export class GameService {
     await this.prisma.device.delete({ where: { id: deviceId } });
   }
 
+  async deleteGame(gameId: string): Promise<void> {
+    const existing = await this.prisma.game.findUnique({ where: { id: gameId } });
+    if (!existing) {
+      throw this.notFound("Game not found");
+    }
+    await this.prisma.game.delete({ where: { id: gameId } });
+  }
+
   async listAllDevices(): Promise<DeviceSummary[]> {
     const devices = await this.prisma.device.findMany({
       orderBy: { createdAt: "asc" },

--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -1907,6 +1907,64 @@
   }
 }
 
+.btn.danger {
+  background: transparent;
+  color: #e57373;
+  border: 1px solid rgba(229, 115, 115, 0.6);
+}
+
+.btn.danger:hover:not(:disabled) {
+  background: rgba(229, 115, 115, 0.12);
+}
+
+.btn.danger:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+@media (prefers-color-scheme: light) {
+  .btn.danger {
+    color: #c62828;
+    border-color: rgba(198, 40, 40, 0.45);
+  }
+
+  .btn.danger:hover:not(:disabled) {
+    background: rgba(198, 40, 40, 0.08);
+  }
+}
+
+.edit-game-danger {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  max-width: 32rem;
+}
+
+.edit-game-danger-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.edit-game-danger-text {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.edit-game-delete-confirm-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 1rem;
+  font-size: 0.9rem;
+}
+
+@media (prefers-color-scheme: light) {
+  .edit-game-danger {
+    border-top-color: rgba(0, 0, 0, 0.12);
+  }
+}
+
 .btn.primary.game-sheet-button {
   background: #2e7d32;
   color: #fff;

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -228,6 +228,8 @@ export const api = {
       body: import("../types/gameDay").UpdateGameInput
     ) =>
       request<GameAggregate>(`/games/${id}`, { method: "PATCH", json: body }),
+    delete: (id: string) =>
+      request<void>(`/games/${id}`, { method: "DELETE" }),
     getAggregate: (id: string) =>
       request<GameAggregate>(`/games/${id}`),
     getRoster: (

--- a/web-app/src/pages/EditGame.tsx
+++ b/web-app/src/pages/EditGame.tsx
@@ -10,6 +10,7 @@ import type { UpdateGameInput } from "../types/gameDay";
 const LEVELS = ["Varsity", "JV", "10U", "12U", "14U", "16U", "18U", "Masters", ""];
 const GENDERS = ["Boys", "Girls", "Co-ed", ""];
 const GAME_TYPES = ["League", "Tournament", "Scrimmage", "Practice", ""];
+const DELETE_CONFIRM_WORD = "delete";
 const MS_PER_MIN = 60 * 1000;
 function msToMinutes(ms: number): number {
   return Math.round(ms / MS_PER_MIN);
@@ -23,6 +24,11 @@ export function EditGame() {
   const navigate = useNavigate();
   const [error, setError] = useState<unknown>(null);
   const [form, setForm] = useState<UpdateGameInput>({});
+  const [matchupLabel, setMatchupLabel] = useState<string | null>(null);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const [deleteError, setDeleteError] = useState<unknown>(null);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     if (!gameDayId || !gameId) return;
@@ -31,6 +37,7 @@ export function EditGame() {
       .then((gd) => {
         const game = gd.games.find((g) => g.id === gameId);
         if (game) {
+          setMatchupLabel(`${game.homeTeamName} vs ${game.awayTeamName}`);
           setForm({
             homeTeamName: game.homeTeamName,
             awayTeamName: game.awayTeamName,
@@ -45,6 +52,12 @@ export function EditGame() {
       })
       .catch((e) => setError(e));
   }, [gameDayId, gameId]);
+
+  const closeDeleteModal = () => {
+    setDeleteModalOpen(false);
+    setDeleteConfirmText("");
+    setDeleteError(null);
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -65,9 +78,24 @@ export function EditGame() {
       .catch((e) => setError(e));
   };
 
+  const handleDeleteConfirm = () => {
+    if (!gameId || deleteConfirmText !== DELETE_CONFIRM_WORD) return;
+    setDeleteError(null);
+    setDeleting(true);
+    api.games
+      .delete(gameId)
+      .then(() => navigate(`/game-days/${gameDayId}`))
+      .catch((e) => {
+        setDeleteError(e);
+        setDeleting(false);
+      });
+  };
+
   if (isDatabaseUnavailableError(error)) {
     return <DatabaseUnavailable />;
   }
+
+  const deleteConfirmed = deleteConfirmText === DELETE_CONFIRM_WORD;
 
   return (
     <div className="page">
@@ -179,6 +207,83 @@ export function EditGame() {
           </Link>
         </div>
       </form>
+
+      <section className="edit-game-danger" aria-labelledby="edit-game-delete-heading">
+        <h2 id="edit-game-delete-heading" className="edit-game-danger-title">
+          Delete game
+        </h2>
+        <p className="edit-game-danger-text">
+          Permanently removes this game, including score, roster, game sheet events, and clock
+          state. This cannot be undone.
+        </p>
+        <button
+          type="button"
+          className="btn danger"
+          onClick={() => setDeleteModalOpen(true)}
+        >
+          Delete game…
+        </button>
+      </section>
+
+      {deleteModalOpen ? (
+        <div
+          className="modal-backdrop"
+          role="dialog"
+          aria-modal
+          aria-labelledby="edit-game-delete-modal-title"
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget && !deleting) closeDeleteModal();
+          }}
+        >
+          <div className="modal" onMouseDown={(e) => e.stopPropagation()}>
+            <h3 id="edit-game-delete-modal-title">Delete this game?</h3>
+            <p className="modal-text">
+              {matchupLabel != null ? (
+                <>
+                  You are about to permanently delete <strong>{matchupLabel}</strong>.
+                </>
+              ) : (
+                <>You are about to permanently delete this game.</>
+              )}
+            </p>
+            <p className="modal-warning">
+              All score, roster, timeline, and clock data for this game will be removed.
+            </p>
+            {deleteError != null ? (
+              <p className="error">{formatApiErrorMessage(deleteError)}</p>
+            ) : null}
+            <label className="edit-game-delete-confirm-label">
+              Type <strong>delete</strong> to confirm
+              <input
+                type="text"
+                autoComplete="off"
+                spellCheck={false}
+                value={deleteConfirmText}
+                onChange={(e) => setDeleteConfirmText(e.target.value)}
+                disabled={deleting}
+              />
+            </label>
+            <div className="form-actions modal-actions">
+              <button
+                type="button"
+                className="btn danger"
+                disabled={!deleteConfirmed || deleting}
+                onClick={handleDeleteConfirm}
+              >
+                {deleting ? "Deleting…" : "Delete game"}
+              </button>
+              <button
+                type="button"
+                className="btn secondary"
+                disabled={deleting}
+                onClick={closeDeleteModal}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
# Game Deletion Support

## Summary

Adds the ability to permanently delete a game from PoloDeck, with a typed confirmation step to reduce the risk of accidental removals.

## Changes

### API

- Added `GameService.deleteGame()` to remove a game by ID.
  - Returns `404 Not Found` when the game does not exist.
- Added `DELETE /api/games/:id` endpoint.
  - Returns `204 No Content` on success.
- Documented the endpoint in `api/README.md`.

### Data Cleanup

- Leverages existing Prisma cascade relationships to automatically remove related data:
  - Scores
  - Clocks
  - Events
  - Rosters
  - Exclusions
  - Timeout state
- `GameDay.activeGameId` and `Device.gameId` are cleared automatically via `onDelete: SetNull`.
- No database migration required.

### Web Application

- Added `api.games.delete(id)` to the API client.
- Added a **Delete Game** danger zone beneath the game edit form.
- Deletion requires typing `delete` exactly before the destructive action is enabled.
- Confirmation modal:
  - Displays the matchup name.
  - Explains which data will be removed.
  - Redirects back to the game day page after successful deletion.
- Error messages are surfaced within the modal.
- Controls are disabled while the delete request is in progress.

### UI

- Added `.btn.danger` styling for destructive actions.
- Added edit-game danger-zone styling.
- Supports both dark and light themes.

<img width="529" height="429" alt="image" src="https://github.com/user-attachments/assets/684c10ac-1023-4cc0-bee1-9809cc06e3ff" />
