### PR TITLE
Fix #63 - Quarter Break and Halftime Workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ Thumbs.db
 *~
 
 # Prisma
-# Keep schema and migrations; ignore generated client in repo (generated on install)
-# server/node_modules/.prisma is inside node_modules, so already ignored
+# Keep schema and migrations; generated client is created by `prisma generate` (api postinstall)
+api/src/generated/
 
 # Docker
 docker-compose.override.yml

--- a/COMMAND_LIST.md
+++ b/COMMAND_LIST.md
@@ -1,0 +1,109 @@
+# PoloDeck command list
+
+Quick reference for **game sheet scoring commands**: enter text in the **Scoring command** field on a game’s sheet and press **Apply**. The same content is available in the web app via the **?** (command help) button on that page.
+
+Commands are parsed case-insensitively unless noted.
+
+---
+
+## Quarter and break
+
+| Input | Also accepted | What it does |
+| --- | --- | --- |
+| `sq` | — | **Start quarter** — If a break is **active** (`sb` already used), ends the break and advances to the next period. If a break is **pending** (after `eq`, before `sb`), skips the pending break and advances. Otherwise starts the game clock for the current period (when allowed). |
+| `eq` | — | **End quarter** — Stops clocks; does **not** start the break countdown. After regulation Q4 with a tied score, the UI may prompt for overtime instead of ending the game. |
+| `sb` | `startbreak` | **Start break** — Begins the break/halftime **game clock** countdown (use after `eq` when a break applies). |
+
+---
+
+## Game and shot clock (shortcuts)
+
+| Input | Also accepted | What it does |
+| --- | --- | --- |
+| `c` | `clock` | **Toggle game clock** — Start if stopped, stop if running. |
+| `r` | `reset` | **Reset shot clock** — Full shot time from game settings (same behavior as a shot reset elsewhere: if the game clock is running, the shot may resume running after reset). |
+
+### After `eq`, before `sb` (break pending)
+
+**`c`** and **`r`** are blocked until you run **`sb`** (or use the Timer flow to start the break). You’ll see an error telling you to start the break first.
+
+---
+
+## Game clock time (optional prefix)
+
+Use at the **start** of goals, exclusions, penalties, and timeouts when you want a specific time on the log entry.
+
+| Form | Meaning |
+| --- | --- |
+| `6.07` or `6:07` | 6 minutes 7 seconds |
+| `6` or `6.` | 6 minutes 0 seconds |
+| `.03` | 3 seconds (sub‑minute) |
+
+If you omit the time, the **current game clock** (as on the scoreboard) is recorded for that entry.
+**Important:** Typing a goal/timeout/etc. does **not** start or stop the live clocks — use **`c`** or the **Timer** page for that.
+
+---
+
+## Team letters (home = dark, away = light)
+
+| Letter | Team |
+| --- | --- |
+| `b` or `d` | Dark (**home**) |
+| `w` or `l` | Light (**away**) |
+
+---
+
+## Goals, exclusions, and penalties
+
+Cap number is required. **Two word orders** are allowed; optional time goes **first**.
+
+### Pattern A — `[time]` `team` `cap` `action`
+
+Examples: `w13g`, `6.07w13g`, `5.53b2e`
+
+### Pattern B — `[time]` `action` `cap` `team`
+
+Examples: `g13w`, `6.07g13w`
+
+| Action letter | Meaning |
+| --- | --- |
+| `g` | Goal |
+| `e` | Exclusion |
+| `p` | Penalty |
+
+---
+
+## Timeouts
+
+Optional time prefix, then **`t`** (full) or **`t3`** (30 seconds), then team letter.
+
+| Example | Meaning |
+| --- | --- |
+| `tw` | Light — full timeout (time = current game clock if no prefix) |
+| `tb` | Dark — full timeout |
+| `4.13tw` | Light — full timeout at 4:13 |
+| `t3w` | Light — 30 second timeout |
+| `4.13t3b` | Dark — 30 second timeout at 4:13 |
+
+---
+
+## Example commands
+
+``` text
+sq
+eq
+sb
+c
+r
+w13g
+6:50w13g
+5.53b2e
+g13w
+tw
+4.13tw
+4.13t3w
+```
+
+Invalid input shows a short hint listing these patterns.
+
+---

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Everything runs on the pool deck over local WiFi—no internet required.
 
+**Operator commands:** [Command list](COMMAND_LIST.md) — scoring shortcuts for the game sheet (`sq`, `eq`, goals, timeouts, etc.).
+
 ## Overview
 
 - **Central server** is the single source of truth for game state; clients send commands and never run their own timers.
@@ -27,7 +29,7 @@ Updates are pushed to clients in real time via **Socket.IO** (`game:stateUpdated
 
 ## Tech stack
 
-| Layer       | Choices                                                                 |
+| Layer      | Choices                                                                  |
 |------------|--------------------------------------------------------------------------|
 | Backend    | Node.js, TypeScript, Fastify, Socket.IO, Prisma, PostgreSQL, Zod, dotenv |
 | Frontend   | Vite, React, TypeScript                                                  |
@@ -55,6 +57,7 @@ PoloDeck/
 │   ├── docker-compose.yml
 │   ├── setup.sh
 │   └── .env.example
+├── COMMAND_LIST.md   # Game sheet scoring commands (printable reference)
 └── README.md
 ```
 
@@ -133,4 +136,3 @@ Early MVP scaffold:
 - Backend: game model, timing, rosters, exclusions, timeouts, device check-in, event log.
 - Game-day planning and game metadata APIs are in place.
 - UI: first pass game-day admin UI built with React (no auth, no production hardening yet).
-

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,6 +6,7 @@ ENV NODE_ENV=production
 
 COPY package.json tsconfig.json tsconfig.build.json ./
 COPY prisma ./prisma
+COPY scripts ./scripts
 COPY src ./src
 
 RUN npm install && npx prisma generate && npm run build

--- a/api/README.md
+++ b/api/README.md
@@ -35,7 +35,7 @@ The backend is designed to run entirely on a local network without internet acce
 cp .env.example .env
 ```
 
-2. Adjust values as needed, especially `DATABASE_URL` if you are not using the provided [`setup/docker-compose.yml`](../setup/docker-compose.yml).
+1. Adjust values as needed, especially `DATABASE_URL` if you are not using the provided [`setup/docker-compose.yml`](../setup/docker-compose.yml).
 
 ---
 
@@ -85,26 +85,38 @@ cd ../setup && docker compose exec polodeck-api npm run db:seed
 npm install
 ```
 
-4. Apply Prisma migrations and generate the client:
+1. Apply Prisma migrations and generate the client:
 
 ```bash
 npx prisma migrate dev --name init
 npx prisma generate
 ```
 
-5. (Optional) Seed example data:
+1. (Optional) Seed example data:
 
 ```bash
 npm run db:seed
 ```
 
-6. Start the development server:
+1. Start the development server:
 
 ```bash
 npm run dev
 ```
 
 The server will listen on `http://localhost:3000`.
+
+### Restart / production vs dev
+
+| How you run | Command |
+| ------------- | --------- |
+| **Local dev** (recommended while coding) | `npm run dev` — runs TypeScript via `tsx watch` |
+| **Compiled** | `npm run build` then `npm start` — needs `copy:prisma-client` (included in `build`) |
+| **Docker** | `./setup/setup.sh restart-api` from repo root — rebuilds the API image |
+
+`npm run dev` works even when `npm start` or the Docker API container fails, because dev loads `src/` directly. If restart fails with `Cannot find module '../generated/prisma'`, run `npm run build` (or rebuild the Docker API).
+
+**Port 3000 already in use:** stop the other process (`lsof -i :3000`) or stop Docker API (`docker stop polodeck-api`) before starting dev again.
 
 ---
 
@@ -131,11 +143,15 @@ Key models:
 npx prisma migrate dev --name init
 ```
 
-- **Generate Prisma client**:
+- **Generate Prisma client** (writes to `src/generated/prisma`; also runs on `npm install` via `postinstall`):
 
 ```bash
 npx prisma generate
 ```
+
+Application code imports enums and `PrismaClient` from `@lib/prisma` (not `@prisma/client` directly), so the IDE uses the same generated types as the compiler.
+
+If TypeScript still shows missing `BreakPhase` or break fields after schema changes, run `npx prisma generate` again, then **TypeScript: Restart TS Server** in the editor.
 
 - **Open Prisma Studio**:
 
@@ -397,5 +413,3 @@ socket.on("game:hornTriggered", ({ gameId, reason }) => {
 - This scaffold focuses on core game operations and event logging, not authentication or multi-tenant concerns.
 - Player exclusion and timeout rules may be refined further to match detailed competition regulations.
 - Additional event types can be added to `GameEventType` as the system evolves.
-
-

--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,10 @@
   "main": "dist/server.js",
   "scripts": {
     "dev": "tsx watch src/server.ts",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && npm run copy:prisma-client",
+    "copy:prisma-client": "node scripts/copy-prisma-client.mjs",
+    "postinstall": "prisma generate",
+    "prestart": "npm run copy:prisma-client",
     "start": "node dist/server.js",
     "lint": "echo \"no linter configured\"",
     "prisma:migrate": "prisma migrate dev",

--- a/api/prisma/migrations/20260526120000_add_break_phase/migration.sql
+++ b/api/prisma/migrations/20260526120000_add_break_phase/migration.sql
@@ -1,0 +1,11 @@
+-- CreateEnum
+CREATE TYPE "BreakPhase" AS ENUM ('NONE', 'QUARTER_BREAK', 'HALFTIME');
+
+-- AlterEnum
+ALTER TYPE "GameEventType" ADD VALUE 'BREAK_STARTED';
+ALTER TYPE "GameEventType" ADD VALUE 'BREAK_ENDED';
+
+-- AlterTable
+ALTER TABLE "Game" ADD COLUMN     "shotClockDurationMs" INTEGER NOT NULL DEFAULT 30000,
+ADD COLUMN     "breakPhase" "BreakPhase" NOT NULL DEFAULT 'NONE',
+ADD COLUMN     "breakAfterPeriod" INTEGER;

--- a/api/prisma/migrations/20260526140000_add_quarter_ended_event/migration.sql
+++ b/api/prisma/migrations/20260526140000_add_quarter_ended_event/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "GameEventType" ADD VALUE 'QUARTER_ENDED';

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  output   = "../src/generated/prisma"
 }
 
 datasource db {
@@ -30,6 +31,12 @@ enum DeviceType {
   TIMER
 }
 
+enum BreakPhase {
+  NONE
+  QUARTER_BREAK
+  HALFTIME
+}
+
 enum GameEventType {
   GAME_CREATED
   GOAL_HOME
@@ -43,6 +50,9 @@ enum GameEventType {
   SHOT_CLOCK_RESET_UNDONE
   SHOT_CLOCK_SET
   PERIOD_ADVANCED
+  QUARTER_ENDED
+  BREAK_STARTED
+  BREAK_ENDED
   EXCLUSION_STARTED
   EXCLUSION_CLEARED
   TIMEOUT_USED
@@ -80,6 +90,9 @@ model Game {
   quarterDurationMs             Int       @default(480000)   // 8 min per quarter
   breakBetweenQuartersDurationMs Int       @default(120000)  // 2 min
   halftimeDurationMs            Int       @default(300000)   // 5 min
+  shotClockDurationMs           Int       @default(30000)    // regulation shot length
+  breakPhase                    BreakPhase @default(NONE)
+  breakAfterPeriod              Int?
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, TeamSide } from "@prisma/client";
+import { PrismaClient, TeamSide } from "../src/generated/prisma";
 
 const prisma = new PrismaClient();
 

--- a/api/scripts/copy-prisma-client.mjs
+++ b/api/scripts/copy-prisma-client.mjs
@@ -1,0 +1,25 @@
+/**
+ * Production build expects dist/lib/prisma.js to require ../generated/prisma.
+ * tsc does not emit the Prisma-generated package; copy it after compile.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const src = path.join(root, "src", "generated", "prisma");
+const dest = path.join(root, "dist", "generated", "prisma");
+
+if (!fs.existsSync(src)) {
+  console.error(
+    "copy-prisma-client: missing",
+    src,
+    "\nRun: npx prisma generate"
+  );
+  process.exit(1);
+}
+
+fs.rmSync(dest, { recursive: true, force: true });
+fs.mkdirSync(path.dirname(dest), { recursive: true });
+fs.cpSync(src, dest, { recursive: true });
+console.log("copy-prisma-client:", path.relative(root, dest));

--- a/api/src/lib/prisma.ts
+++ b/api/src/lib/prisma.ts
@@ -1,0 +1,15 @@
+/**
+ * Prisma enums and client — import from here in application code.
+ * Re-exports from src/generated/prisma (see prisma/schema.prisma `output`).
+ * `npm run build` copies that package into dist/generated for `node dist/server.js`.
+ */
+export {
+  Prisma,
+  PrismaClient,
+  BreakPhase,
+  DeviceType,
+  ExclusionStatus,
+  GameEventType,
+  GameStatus,
+  TeamSide,
+} from "../generated/prisma";

--- a/api/src/plugins/prisma.ts
+++ b/api/src/plugins/prisma.ts
@@ -1,5 +1,5 @@
 import fp from "fastify-plugin";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "../lib/prisma";
 import type { FastifyInstance } from "fastify";
 
 declare module "fastify" {

--- a/api/src/routes/games.ts
+++ b/api/src/routes/games.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from "fastify";
-import { DeviceType, TeamSide } from ".prisma/client";
+import { DeviceType, TeamSide } from "../lib/prisma";
 import { env } from "../config/env";
 import {
   addPlayerBodySchema,
@@ -208,7 +208,9 @@ export async function registerGameRoutes(app: FastifyInstance) {
   app.post("/games/:id/period/set", async (request) => {
     const params = gameIdParamSchema.parse(request.params);
     const body = setGamePeriodBodySchema.parse(request.body);
-    return service.setGamePeriod(params.id, body.period);
+    return service.setGamePeriod(params.id, body.period, {
+      halftime: body.halftime,
+    });
   });
 
   // Roster

--- a/api/src/schemas/game.schemas.ts
+++ b/api/src/schemas/game.schemas.ts
@@ -1,4 +1,4 @@
-import { GameEventType } from ".prisma/client";
+import { GameEventType } from "../lib/prisma";
 import { z } from "zod";
 
 // Game day
@@ -67,6 +67,8 @@ export const setClockBodySchema = z.object({
 
 export const setGamePeriodBodySchema = z.object({
   period: z.number().int().min(1),
+  /** Scoreboard "Half time" — enter halftime break after Q2 (period stays 2 until sq). */
+  halftime: z.boolean().optional(),
 });
 
 export const addPlayerBodySchema = z.object({
@@ -92,6 +94,9 @@ export const scoreCommandBodySchema = z.object({
   type: z.enum([
     "START_QUARTER",
     "END_QUARTER",
+    "START_BREAK",
+    "TOGGLE_GAME_CLOCK",
+    "RESET_SHOT_CLOCK",
     "GOAL",
     "EXCLUSION",
     "PENALTY",

--- a/api/src/services/game.service.ts
+++ b/api/src/services/game.service.ts
@@ -1,5 +1,12 @@
 import type { FastifyInstance } from "fastify";
-import { DeviceType, GameEventType, GameStatus, TeamSide, type Prisma } from ".prisma/client";
+import {
+  BreakPhase,
+  DeviceType,
+  GameEventType,
+  GameStatus,
+  TeamSide,
+  type Prisma,
+} from "../lib/prisma";
 import {
   startClock,
   stopClock,
@@ -527,6 +534,7 @@ export class GameService {
         quarterDurationMs,
         breakBetweenQuartersDurationMs,
         halftimeDurationMs,
+        shotClockDurationMs,
         score: { create: {} },
         gameClock: {
           create: {
@@ -626,7 +634,11 @@ export class GameService {
         where: { id: gameId },
         data,
       });
-      if (input.quarterDurationMs !== undefined && existing.gameClock) {
+      if (
+        input.quarterDurationMs !== undefined &&
+        existing.gameClock &&
+        existing.breakPhase === BreakPhase.NONE
+      ) {
         const g = existing.gameClock;
         const d = input.quarterDurationMs;
         const eff = getEffectiveRemainingMs(
@@ -649,28 +661,34 @@ export class GameService {
           },
         });
       }
-      if (input.shotClockDurationMs !== undefined && existing.shotClock) {
-        const s = existing.shotClock;
-        const d = input.shotClockDurationMs;
-        const eff = getEffectiveRemainingMs(
-          {
-            durationMs: s.durationMs,
-            remainingMs: s.remainingMs,
-            running: s.running,
-            lastStartedAt: s.lastStartedAt,
-          },
-          now
-        );
-        const newRem = s.running ? Math.min(eff, d) : d;
-        await tx.shotClock.update({
-          where: { id: s.id },
-          data: {
-            durationMs: d,
-            remainingMs: newRem,
-            lastStartedAt: s.running ? new Date(now) : null,
-            running: s.running,
-          },
+      if (input.shotClockDurationMs !== undefined) {
+        await tx.game.update({
+          where: { id: gameId },
+          data: { shotClockDurationMs: input.shotClockDurationMs },
         });
+        if (existing.shotClock && existing.breakPhase === BreakPhase.NONE) {
+          const s = existing.shotClock;
+          const d = input.shotClockDurationMs;
+          const eff = getEffectiveRemainingMs(
+            {
+              durationMs: s.durationMs,
+              remainingMs: s.remainingMs,
+              running: s.running,
+              lastStartedAt: s.lastStartedAt,
+            },
+            now
+          );
+          const newRem = s.running ? Math.min(eff, d) : d;
+          await tx.shotClock.update({
+            where: { id: s.id },
+            data: {
+              durationMs: d,
+              remainingMs: newRem,
+              lastStartedAt: s.running ? new Date(now) : null,
+              running: s.running,
+            },
+          });
+        }
       }
     });
     return this.emitState(gameId);
@@ -755,7 +773,7 @@ export class GameService {
   async startGameClock(gameId: string) {
     const game = await this.prisma.game.findUnique({
       where: { id: gameId },
-      select: { currentPeriod: true },
+      select: { currentPeriod: true, breakPhase: true },
     });
     if (!game) {
       throw this.notFound("Game not found");
@@ -795,9 +813,10 @@ export class GameService {
         "operator"
       );
     }
-    // Always resync the shot: materialize then start (repairs "running" without lastStartedAt, or
-    // a stale pre-coupling shot-while-game-stopped state).
-    await this.resyncShotClockWithGameStart(gameId);
+    // During breaks the shot clock stays at 00 — do not resync with game start.
+    if (game.breakPhase === BreakPhase.NONE) {
+      await this.resyncShotClockWithGameStart(gameId);
+    }
     return this.emitState(gameId);
   }
 
@@ -957,6 +976,15 @@ export class GameService {
       );
     }
     return this.emitState(gameId);
+  }
+
+  private assertClockCommandsAllowed(game: {
+    breakAfterPeriod: number | null;
+    breakPhase: BreakPhase;
+  }) {
+    if (game.breakAfterPeriod != null && game.breakPhase === BreakPhase.NONE) {
+      throw this.badRequest("Start break with sb before using clock commands.");
+    }
   }
 
   async startShotClock(gameId: string) {
@@ -1169,6 +1197,263 @@ export class GameService {
     return this.emitState(gameId);
   }
 
+  /** Regulation shot length while not in a break (break overwrites clock rows). */
+  private getRegulationShotDurationMs(game: { shotClockDurationMs: number }): number {
+    return game.shotClockDurationMs;
+  }
+
+  private getBreakConfig(
+    game: {
+      currentPeriod: number;
+      totalPeriods: number;
+      breakBetweenQuartersDurationMs: number;
+      halftimeDurationMs: number;
+    },
+    afterPeriod: number
+  ): { kind: BreakPhase; durationMs: number } | null {
+    if (afterPeriod >= game.totalPeriods) return null;
+    if (afterPeriod === 2) {
+      if (game.halftimeDurationMs <= 0) return null;
+      return { kind: BreakPhase.HALFTIME, durationMs: game.halftimeDurationMs };
+    }
+    if (game.breakBetweenQuartersDurationMs <= 0) return null;
+    return {
+      kind: BreakPhase.QUARTER_BREAK,
+      durationMs: game.breakBetweenQuartersDurationMs,
+    };
+  }
+
+  private async setClocksToBreakDuration(
+    gameId: string,
+    durationMs: number,
+    running: boolean
+  ): Promise<void> {
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      include: { gameClock: true, shotClock: true },
+    });
+    if (!game?.gameClock || !game.shotClock) {
+      throw this.notFound("Game clocks not found");
+    }
+    await this.prisma.gameClock.update({
+      where: { id: game.gameClock.id },
+      data: {
+        durationMs,
+        remainingMs: durationMs,
+        running,
+        lastStartedAt: running ? new Date() : null,
+      },
+    });
+    await this.prisma.shotClock.update({
+      where: { id: game.shotClock.id },
+      data: {
+        durationMs: 0,
+        remainingMs: 0,
+        running: false,
+        lastStartedAt: null,
+      },
+    });
+  }
+
+  /** After eq: mark break pending or finalize/skip when no break applies. */
+  private async afterQuarterEnded(gameId: string, afterPeriod: number) {
+    const game = await this.prisma.game.findUnique({ where: { id: gameId } });
+    if (!game) throw this.notFound("Game not found");
+
+    if (afterPeriod >= game.totalPeriods) {
+      await this.prisma.game.update({
+        where: { id: gameId },
+        data: { status: GameStatus.FINAL, breakAfterPeriod: null },
+      });
+      return this.emitState(gameId);
+    }
+
+    const config = this.getBreakConfig(game, afterPeriod);
+    if (!config) {
+      return this.advancePeriod(gameId);
+    }
+
+    await this.prisma.game.update({
+      where: { id: gameId },
+      data: {
+        breakAfterPeriod: afterPeriod,
+        breakPhase: BreakPhase.NONE,
+        status: GameStatus.IN_PROGRESS,
+      },
+    });
+    await this.createEvent(
+      gameId,
+      GameEventType.QUARTER_ENDED,
+      { afterPeriod } as Prisma.InputJsonValue,
+      "operator"
+    );
+    return this.emitState(gameId);
+  }
+
+  /** sq while break pending: skip break and advance to next period. */
+  private async skipPendingBreakAndAdvancePeriod(gameId: string) {
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      include: { score: true },
+    });
+    if (!game) throw this.notFound("Game not found");
+
+    const from = game.currentPeriod;
+    const nextPeriod = Math.min(game.totalPeriods, from + 1);
+
+    await this.prisma.game.update({
+      where: { id: gameId },
+      data: {
+        breakAfterPeriod: null,
+        breakPhase: BreakPhase.NONE,
+        currentPeriod: nextPeriod,
+        status: GameStatus.IN_PROGRESS,
+      },
+    });
+
+    const payload: Record<string, unknown> = {
+      from,
+      to: nextPeriod,
+      skippedBreak: true,
+    };
+    if (game.score) {
+      payload.homeScore = game.score.homeScore;
+      payload.awayScore = game.score.awayScore;
+    }
+    await this.createEvent(
+      gameId,
+      GameEventType.PERIOD_ADVANCED,
+      payload as Prisma.InputJsonValue,
+      "operator"
+    );
+    await this.resetClocksForQuarterPlay(gameId);
+    return this.emitState(gameId);
+  }
+
+  private async resetClocksForQuarterPlay(gameId: string): Promise<void> {
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      include: { gameClock: true, shotClock: true },
+    });
+    if (!game?.gameClock || !game.shotClock) {
+      throw this.notFound("Game clocks not found");
+    }
+    const quarterMs = game.quarterDurationMs;
+    const shotMs = this.getRegulationShotDurationMs(game);
+    await this.prisma.gameClock.update({
+      where: { id: game.gameClock.id },
+      data: {
+        durationMs: quarterMs,
+        remainingMs: quarterMs,
+        running: false,
+        lastStartedAt: null,
+      },
+    });
+    await this.prisma.shotClock.update({
+      where: { id: game.shotClock.id },
+      data: {
+        durationMs: shotMs,
+        remainingMs: shotMs,
+        running: false,
+        lastStartedAt: null,
+      },
+    });
+  }
+
+  async startBreak(gameId: string, afterPeriod: number) {
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      include: { gameClock: true, shotClock: true },
+    });
+    if (!game) throw this.notFound("Game not found");
+
+    if (game.breakPhase !== BreakPhase.NONE) {
+      return this.emitState(gameId);
+    }
+
+    const config = this.getBreakConfig(game, afterPeriod);
+    if (!config) {
+      if (afterPeriod >= game.totalPeriods) {
+        await this.prisma.game.update({
+          where: { id: gameId },
+          data: { status: GameStatus.FINAL },
+        });
+        return this.emitState(gameId);
+      }
+      return this.advancePeriod(gameId);
+    }
+
+    await this.setClocksToBreakDuration(gameId, config.durationMs, false);
+    await this.prisma.game.update({
+      where: { id: gameId },
+      data: {
+        breakPhase: config.kind,
+        breakAfterPeriod: afterPeriod,
+        status: GameStatus.IN_PROGRESS,
+      },
+    });
+
+    await this.createEvent(
+      gameId,
+      GameEventType.BREAK_STARTED,
+      {
+        kind: config.kind,
+        afterPeriod,
+        durationMs: config.durationMs,
+      } as Prisma.InputJsonValue,
+      "operator"
+    );
+    return this.emitState(gameId);
+  }
+
+  async endBreakAndAdvancePeriod(gameId: string) {
+    const game = await this.prisma.game.findUnique({
+      where: { id: gameId },
+      include: { score: true },
+    });
+    if (!game) throw this.notFound("Game not found");
+
+    if (game.breakPhase === BreakPhase.NONE) {
+      return this.emitState(gameId);
+    }
+
+    const afterPeriod = game.breakAfterPeriod ?? game.currentPeriod;
+    const from = game.currentPeriod;
+    const nextPeriod = Math.min(game.totalPeriods, from + 1);
+
+    await this.prisma.game.update({
+      where: { id: gameId },
+      data: {
+        breakPhase: BreakPhase.NONE,
+        breakAfterPeriod: null,
+        currentPeriod: nextPeriod,
+        status: GameStatus.IN_PROGRESS,
+      },
+    });
+
+    await this.createEvent(
+      gameId,
+      GameEventType.BREAK_ENDED,
+      { afterPeriod } as Prisma.InputJsonValue,
+      "operator"
+    );
+
+    const payload: Record<string, unknown> = { from, to: nextPeriod, fromBreak: true };
+    if (game.score) {
+      payload.homeScore = game.score.homeScore;
+      payload.awayScore = game.score.awayScore;
+    }
+    await this.createEvent(
+      gameId,
+      GameEventType.PERIOD_ADVANCED,
+      payload as Prisma.InputJsonValue,
+      "operator"
+    );
+
+    await this.resetClocksForQuarterPlay(gameId);
+    return this.emitState(gameId);
+  }
+
   async advancePeriod(gameId: string) {
     const game = await this.prisma.game.findUnique({
       where: { id: gameId },
@@ -1178,19 +1463,17 @@ export class GameService {
       throw this.notFound("Game not found");
     }
 
-    const nextPeriod = Math.min(game.totalPeriods, game.currentPeriod + 1);
+    const from = game.currentPeriod;
+    const nextPeriod = Math.min(game.totalPeriods, from + 1);
 
     const data: { currentPeriod: number; status?: GameStatus } = { currentPeriod: nextPeriod };
-    if (game.totalPeriods === 4 && nextPeriod === 4) {
-      data.status = GameStatus.FINAL;
-    }
     await this.prisma.game.update({
       where: { id: gameId },
       data,
     });
 
     const payload: Record<string, unknown> = {
-      from: game.currentPeriod,
+      from,
       to: nextPeriod,
     };
     if (game.score) {
@@ -1206,13 +1489,32 @@ export class GameService {
     return this.emitState(gameId);
   }
 
-  async setGamePeriod(gameId: string, targetPeriod: number) {
+  async setGamePeriod(
+    gameId: string,
+    targetPeriod: number,
+    options?: { halftime?: boolean }
+  ) {
     const game = await this.prisma.game.findUnique({
       where: { id: gameId },
       include: { score: true, gameClock: true, shotClock: true },
     });
     if (!game) {
       throw this.notFound("Game not found");
+    }
+
+    if (options?.halftime === true) {
+      if (game.gameClock?.running) {
+        await this.stopGameClock(gameId);
+      } else if (game.shotClock?.running) {
+        await this.stopShotClock(gameId);
+      }
+      if (game.currentPeriod !== 2) {
+        await this.prisma.game.update({
+          where: { id: gameId },
+          data: { currentPeriod: 2, status: GameStatus.IN_PROGRESS },
+        });
+      }
+      return this.startBreak(gameId, 2);
     }
 
     const expandToOvertime = game.totalPeriods === 4 && targetPeriod === 5;
@@ -1256,32 +1558,53 @@ export class GameService {
     }
 
     const from = game.currentPeriod;
-    if (from !== targetPeriod) {
-      // Scoreboard distinguishes Q4 (last quarter in progress) from game ended; FINAL is PATCH only.
-      const data: { currentPeriod: number; status: GameStatus } = {
+    const clearBreak = game.breakPhase !== BreakPhase.NONE;
+    if (from !== targetPeriod || clearBreak) {
+      const data: {
+        currentPeriod: number;
+        status: GameStatus;
+        breakPhase?: BreakPhase;
+        breakAfterPeriod?: number | null;
+      } = {
         currentPeriod: targetPeriod,
         status: GameStatus.IN_PROGRESS,
       };
+      if (clearBreak) {
+        data.breakPhase = BreakPhase.NONE;
+        data.breakAfterPeriod = null;
+      }
       await this.prisma.game.update({
         where: { id: gameId },
         data,
       });
 
-      const payload: Record<string, unknown> = {
-        from,
-        to: targetPeriod,
-        directSet: true,
-      };
-      if (game.score) {
-        payload.homeScore = game.score.homeScore;
-        payload.awayScore = game.score.awayScore;
+      if (clearBreak) {
+        await this.createEvent(
+          gameId,
+          GameEventType.BREAK_ENDED,
+          { afterPeriod: game.breakAfterPeriod ?? from, directSet: true } as Prisma.InputJsonValue,
+          "operator"
+        );
+        await this.resetClocksForQuarterPlay(gameId);
       }
-      await this.createEvent(
-        gameId,
-        GameEventType.PERIOD_ADVANCED,
-        payload as Prisma.InputJsonValue,
-        "operator"
-      );
+
+      if (from !== targetPeriod) {
+        const payload: Record<string, unknown> = {
+          from,
+          to: targetPeriod,
+          directSet: true,
+        };
+        if (game.score) {
+          payload.homeScore = game.score.homeScore;
+          payload.awayScore = game.score.awayScore;
+        }
+        await this.createEvent(
+          gameId,
+          GameEventType.PERIOD_ADVANCED,
+          payload as Prisma.InputJsonValue,
+          "operator"
+        );
+      }
     }
 
     return this.emitState(gameId);
@@ -1298,8 +1621,14 @@ export class GameService {
     }
     await this.prisma.game.update({
       where: { id: gameId },
-      data: { currentPeriod: 5, totalPeriods: 5 },
+      data: {
+        currentPeriod: 5,
+        totalPeriods: 5,
+        breakPhase: BreakPhase.NONE,
+        breakAfterPeriod: null,
+      },
     });
+    await this.resetClocksForQuarterPlay(gameId);
     const payload: Record<string, unknown> = { from: 4, to: 5 };
     if (game.score) {
       payload.homeScore = game.score.homeScore;
@@ -1495,7 +1824,17 @@ export class GameService {
   async applyScoreCommand(
     gameId: string,
     body: {
-      type: "START_QUARTER" | "END_QUARTER" | "GOAL" | "EXCLUSION" | "PENALTY" | "TIMEOUT" | "TIMEOUT_30";
+      type:
+        | "START_QUARTER"
+        | "END_QUARTER"
+        | "START_BREAK"
+        | "TOGGLE_GAME_CLOCK"
+        | "RESET_SHOT_CLOCK"
+        | "GOAL"
+        | "EXCLUSION"
+        | "PENALTY"
+        | "TIMEOUT"
+        | "TIMEOUT_30";
       timeSeconds?: number;
       side?: "HOME" | "AWAY";
       capNumber?: string;
@@ -1512,6 +1851,31 @@ export class GameService {
           include: { gameClock: true },
         });
         if (!game?.gameClock) throw this.notFound("Game not found");
+        if (game.breakPhase !== BreakPhase.NONE) {
+          return this.endBreakAndAdvancePeriod(gameId);
+        }
+        if (game.breakAfterPeriod != null) {
+          await this.skipPendingBreakAndAdvancePeriod(gameId);
+          const after = await this.prisma.game.findUnique({
+            where: { id: gameId },
+            select: { currentPeriod: true, scheduledAt: true },
+          });
+          if (after?.currentPeriod === 1 && after.scheduledAt == null) {
+            await this.prisma.game.update({
+              where: { id: gameId },
+              data: { scheduledAt: new Date() },
+            });
+          }
+          if (after && !(await this.quarterStartAlreadyLogged(gameId))) {
+            await this.createEvent(
+              gameId,
+              GameEventType.GAME_CLOCK_STARTED,
+              { period: after.currentPeriod },
+              "operator"
+            );
+          }
+          return this.emitState(gameId);
+        }
         if (game.currentPeriod === 1 && game.scheduledAt == null) {
           await this.prisma.game.update({
             where: { id: gameId },
@@ -1533,7 +1897,33 @@ export class GameService {
         if (body.overtime === true) {
           return this.startOvertime(gameId);
         }
-        return this.advancePeriod(gameId);
+        const gameAfterStop = await this.prisma.game.findUnique({ where: { id: gameId } });
+        if (!gameAfterStop) throw this.notFound("Game not found");
+        return this.afterQuarterEnded(gameId, gameAfterStop.currentPeriod);
+      }
+      case "START_BREAK": {
+        const game = await this.prisma.game.findUnique({ where: { id: gameId } });
+        if (!game) throw this.notFound("Game not found");
+        const afterPeriod = game.breakAfterPeriod ?? game.currentPeriod;
+        return this.startBreak(gameId, afterPeriod);
+      }
+      case "TOGGLE_GAME_CLOCK": {
+        const game = await this.prisma.game.findUnique({
+          where: { id: gameId },
+          include: { gameClock: true },
+        });
+        if (!game?.gameClock) throw this.notFound("Game not found");
+        this.assertClockCommandsAllowed(game);
+        if (game.gameClock.running) {
+          return this.stopGameClock(gameId);
+        }
+        return this.startGameClock(gameId);
+      }
+      case "RESET_SHOT_CLOCK": {
+        const game = await this.prisma.game.findUnique({ where: { id: gameId } });
+        if (!game) throw this.notFound("Game not found");
+        this.assertClockCommandsAllowed(game);
+        return this.resetShotClock(gameId);
       }
       case "GOAL": {
         if (side == null || body.capNumber == null) {

--- a/api/src/services/gameEventRerun.ts
+++ b/api/src/services/gameEventRerun.ts
@@ -1,10 +1,11 @@
 import {
+  type Prisma,
+  BreakPhase,
+  ExclusionStatus,
   GameEventType,
   GameStatus,
   TeamSide,
-  ExclusionStatus,
-} from ".prisma/client";
-import type { Prisma } from "@prisma/client";
+} from "../lib/prisma";
 import { startClock, stopClock, setClockRemaining } from "../lib/clock";
 
 export type RebuildEventInput = {
@@ -103,6 +104,8 @@ export async function rerunGameEventLog(
       status: GameStatus.PENDING,
       totalPeriods: initialTotalPeriods,
       scheduledAt: null,
+      breakPhase: BreakPhase.NONE,
+      breakAfterPeriod: null,
     },
   });
 
@@ -379,6 +382,76 @@ export async function rerunGameEventLog(
         break;
       }
 
+      case GameEventType.QUARTER_ENDED: {
+        const p = asPayload(ev.payload);
+        const afterPeriod = typeof p.afterPeriod === "number" ? p.afterPeriod : 1;
+        await tx.game.update({
+          where: { id: gameId },
+          data: {
+            breakAfterPeriod: afterPeriod,
+            breakPhase: BreakPhase.NONE,
+            status: GameStatus.IN_PROGRESS,
+          },
+        });
+        payloadOut = { afterPeriod } as Prisma.InputJsonValue;
+        break;
+      }
+
+      case GameEventType.BREAK_STARTED: {
+        const p = asPayload(ev.payload);
+        const kind =
+          p.kind === BreakPhase.HALFTIME
+            ? BreakPhase.HALFTIME
+            : BreakPhase.QUARTER_BREAK;
+        const afterPeriod = typeof p.afterPeriod === "number" ? p.afterPeriod : 1;
+        const durationMs =
+          typeof p.durationMs === "number" && p.durationMs >= 0 ? p.durationMs : 0;
+        const gClock = await tx.gameClock.findUnique({ where: { gameId } });
+        const sClock = await tx.shotClock.findUnique({ where: { gameId } });
+        if (!gClock || !sClock) throw new Error("Clocks missing for BREAK_STARTED");
+        await tx.gameClock.update({
+          where: { id: gClock.id },
+          data: {
+            durationMs,
+            remainingMs: durationMs,
+            running: false,
+            lastStartedAt: null,
+          },
+        });
+        await tx.shotClock.update({
+          where: { id: sClock.id },
+          data: {
+            durationMs: 0,
+            remainingMs: 0,
+            running: false,
+            lastStartedAt: null,
+          },
+        });
+        await tx.game.update({
+          where: { id: gameId },
+          data: {
+            breakPhase: kind,
+            breakAfterPeriod: afterPeriod,
+            status: GameStatus.IN_PROGRESS,
+          },
+        });
+        payloadOut = { ...p, kind, afterPeriod, durationMs } as Prisma.InputJsonValue;
+        break;
+      }
+
+      case GameEventType.BREAK_ENDED: {
+        const p = asPayload(ev.payload);
+        await tx.game.update({
+          where: { id: gameId },
+          data: {
+            breakPhase: BreakPhase.NONE,
+            breakAfterPeriod: null,
+          },
+        });
+        payloadOut = p as Prisma.InputJsonValue;
+        break;
+      }
+
       case GameEventType.PERIOD_ADVANCED: {
         const p = asPayload(ev.payload);
         const from = typeof p.from === "number" ? p.from : 1;
@@ -392,16 +465,39 @@ export async function rerunGameEventLog(
             data: { currentPeriod: 5, totalPeriods: 5 },
           });
         } else {
-          const data: { currentPeriod: number; status?: GameStatus } = {
-            currentPeriod: to,
-          };
-          if (g.totalPeriods === 4 && to === 4) {
-            data.status = GameStatus.FINAL;
-          }
           await tx.game.update({
             where: { id: gameId },
-            data,
+            data: {
+              currentPeriod: to,
+              status: GameStatus.IN_PROGRESS,
+            },
           });
+          if (p.fromBreak === true || p.skippedBreak === true) {
+            const quarterMs = g.quarterDurationMs;
+            const shotMs = g.shotClockDurationMs;
+            const gClock = await tx.gameClock.findUnique({ where: { gameId } });
+            const sClock = await tx.shotClock.findUnique({ where: { gameId } });
+            if (gClock && sClock) {
+              await tx.gameClock.update({
+                where: { id: gClock.id },
+                data: {
+                  durationMs: quarterMs,
+                  remainingMs: quarterMs,
+                  running: false,
+                  lastStartedAt: null,
+                },
+              });
+              await tx.shotClock.update({
+                where: { id: sClock.id },
+                data: {
+                  durationMs: shotMs,
+                  remainingMs: shotMs,
+                  running: false,
+                  lastStartedAt: null,
+                },
+              });
+            }
+          }
         }
         const scoreRow = await tx.score.findUnique({ where: { gameId } });
         payloadOut = {

--- a/setup/.env.example
+++ b/setup/.env.example
@@ -16,6 +16,9 @@ POSTGRES_PASSWORD=polodeck
 POSTGRES_DB=polodeck
 
 # Build-time URLs baked into the web-app static bundle (browser → API).
-# For LAN access, set these to http://<this-machine-LAN-IP>:3000/... before building.
-VITE_API_URL=http://<your-machine-LAN-IP>:3000/api
-VITE_SOCKET_URL=http://<your-machine-LAN-IP>:3000
+# Recommended for Docker on this machine (open http://localhost:8080):
+VITE_API_URL=/api
+VITE_SOCKET_URL=
+# Only use LAN :3000 URLs if the UI is served without the :8080 nginx proxy (unusual).
+# VITE_API_URL=http://<your-machine-LAN-IP>:3000/api
+# VITE_SOCKET_URL=http://<your-machine-LAN-IP>:3000

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -20,6 +20,7 @@ PoloDeck setup (Docker)
   ./setup/setup.sh migrate      Run prisma migrate deploy in the API container
   ./setup/setup.sh build        docker compose build
   ./setup/setup.sh logs         docker compose logs -f
+  ./setup/setup.sh restart-api  Rebuild and restart the API container (after api code changes)
 
 Environment (non-interactive / CI):
 
@@ -227,6 +228,11 @@ main() {
       ;;
     logs)
       (cd "${SETUP_DIR}" && "${COMPOSE[@]}" logs -f)
+      ;;
+    restart-api)
+      ensure_env_file
+      echo "Rebuilding and restarting polodeck-api…"
+      (cd "${SETUP_DIR}" && "${COMPOSE[@]}" up -d --build polodeck-api)
       ;;
     *)
       echo "error: unknown command: ${cmd}" >&2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./api" }]
+}

--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -816,6 +816,16 @@
   opacity: 0.85;
 }
 
+.scoreboard-break-pending-hint {
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  border-radius: 6px;
+  background: rgba(251, 191, 36, 0.12);
+  color: inherit;
+}
+
 .scoreboard-footer {
   display: flex;
   flex-wrap: wrap;
@@ -2899,6 +2909,13 @@
   gap: 1rem;
 }
 
+.game-timer-start-break {
+  width: 100%;
+  min-height: 3rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
 .game-timer-startstop {
   width: 100%;
   min-height: 3rem;
@@ -3260,6 +3277,41 @@ body:has(.kiosk-scoreboard-display) .app {
   color: #ff1a1a;
   letter-spacing: 0;
   text-shadow: 0 0 12px rgba(255, 255, 255, 0.35);
+}
+
+.kiosk-scoreboard-break {
+  text-align: center;
+  margin-top: clamp(0.75rem, 3vmin, 1.5rem);
+  padding: clamp(0.5rem, 2vmin, 1rem) 0 0;
+  border-top: 2px solid rgba(241, 245, 249, 0.25);
+}
+
+.kiosk-scoreboard-break-label {
+  font-size: clamp(1.25rem, 4vw, 2rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #fbbf24;
+  margin-bottom: 0.35em;
+}
+
+.kiosk-scoreboard-break-time {
+  font-family: "Orbitron", ui-sans-serif, system-ui, sans-serif;
+  font-size: clamp(2.5rem, 10vw, 5rem);
+  font-weight: 700;
+  color: #f1f5f9;
+  font-variant-numeric: tabular-nums;
+}
+
+.kiosk-scoreboard-break-time--running {
+  color: #4ade80;
+}
+
+.kiosk-shotclock-break-label {
+  font-size: clamp(1.5rem, 6vmin, 3rem) !important;
+  color: #fbbf24 !important;
+  text-align: center;
+  letter-spacing: 0.05em;
 }
 
 /* Stretch root chain for portrait shot clock kiosk */

--- a/web-app/src/api/client.ts
+++ b/web-app/src/api/client.ts
@@ -103,10 +103,14 @@ export interface GameAggregate {
   currentPeriod: number;
   totalPeriods: number;
   status: "PENDING" | "IN_PROGRESS" | "FINAL";
+  breakPhase?: "NONE" | "QUARTER_BREAK" | "HALFTIME";
+  /** Quarter that just ended when on a break (for "End Q1" labels). */
+  breakAfterPeriod?: number | null;
   /** Per-period length; mirrors game clock duration. */
   quarterDurationMs?: number;
   breakBetweenQuartersDurationMs?: number;
   halftimeDurationMs?: number;
+  shotClockDurationMs?: number;
   score: {
     homeScore: number;
     awayScore: number;
@@ -258,7 +262,17 @@ export const api = {
     applyScoreCommand: (
       id: string,
       body: {
-        type: "START_QUARTER" | "END_QUARTER" | "GOAL" | "EXCLUSION" | "PENALTY" | "TIMEOUT" | "TIMEOUT_30";
+        type:
+          | "START_QUARTER"
+          | "END_QUARTER"
+          | "START_BREAK"
+          | "TOGGLE_GAME_CLOCK"
+          | "RESET_SHOT_CLOCK"
+          | "GOAL"
+          | "EXCLUSION"
+          | "PENALTY"
+          | "TIMEOUT"
+          | "TIMEOUT_30";
         timeSeconds?: number;
         side?: "HOME" | "AWAY";
         capNumber?: string;
@@ -269,11 +283,11 @@ export const api = {
         method: "POST",
         json: body,
       }),
-    setPeriod: async (id: string, period: number) => {
+    setPeriod: async (id: string, period: number, options?: { halftime?: boolean }) => {
       try {
         return await request<GameAggregate>(`/games/${id}/period/set`, {
           method: "POST",
-          json: { period },
+          json: { period, ...(options?.halftime === true ? { halftime: true } : {}) },
         });
       } catch (e) {
         if (e instanceof ApiError && e.status === 404) {

--- a/web-app/src/lib/clockDisplay.ts
+++ b/web-app/src/lib/clockDisplay.ts
@@ -1,17 +1,135 @@
 import type { GameAggregate } from "../api/client";
 
-/** Period 3 with game clock duration set to the game's halftime length (see scoreboard HT). */
+export type BreakPhase = "NONE" | "QUARTER_BREAK" | "HALFTIME";
+
+export function isGameFinal(
+  aggregate: Pick<GameAggregate, "status">
+): boolean {
+  return aggregate.status === "FINAL";
+}
+
+/** Short phase label: Final, Q1–Q4, OT, or HT during halftime. */
+export function getGamePhaseLabel(
+  aggregate: Pick<GameAggregate, "status" | "currentPeriod" | "breakPhase">
+): string {
+  if (isGameFinal(aggregate)) return "Final";
+  if (aggregate.breakPhase === "HALFTIME") return "HT";
+  if (aggregate.currentPeriod >= 5) return "OT";
+  return `Q${aggregate.currentPeriod}`;
+}
+
+/** Timer / kiosk subtitle: "Final" or "Period 2 of 4". */
+export function getGamePeriodSubtitle(
+  aggregate: Pick<GameAggregate, "status" | "currentPeriod" | "totalPeriods">
+): string {
+  if (isGameFinal(aggregate)) return "Final";
+  return `Period ${aggregate.currentPeriod} of ${aggregate.totalPeriods}`;
+}
+
+/** Game sheet scoreboard footer, e.g. "Period: Final" or "Period: Q3 · HT". */
+export function formatGamePeriodFooter(
+  aggregate: Pick<GameAggregate, "status" | "currentPeriod" | "breakPhase">
+): string {
+  if (isGameFinal(aggregate)) return "Period: Final";
+  if (aggregate.breakPhase === "HALFTIME") {
+    return `Period: Q${aggregate.currentPeriod} · HT`;
+  }
+  return `Period: ${getGamePhaseLabel(aggregate)}`;
+}
+
+export function isOnBreak(
+  aggregate: Pick<GameAggregate, "breakPhase">
+): boolean {
+  return aggregate.breakPhase != null && aggregate.breakPhase !== "NONE";
+}
+
+/** Quarter ended (eq) but break countdown not started yet (sb / Timer). */
+export function isBreakPending(
+  aggregate: Pick<GameAggregate, "breakPhase" | "breakAfterPeriod">
+): boolean {
+  return (
+    !isOnBreak(aggregate) &&
+    aggregate.breakAfterPeriod != null &&
+    aggregate.breakAfterPeriod >= 1
+  );
+}
+
+function labelForEndedPeriod(
+  afterPeriod: number,
+  halftimeDurationMs?: number
+): string {
+  if (afterPeriod === 2 && (halftimeDurationMs ?? 0) > 0) return "Halftime";
+  if (afterPeriod >= 1) return `End Q${afterPeriod}`;
+  return "Break";
+}
+
+/** Label for pending break (before sb). */
+export function getPendingBreakLabel(
+  aggregate: Pick<
+    GameAggregate,
+    "breakPhase" | "breakAfterPeriod" | "halftimeDurationMs"
+  >
+): string | null {
+  if (!isBreakPending(aggregate)) return null;
+  return labelForEndedPeriod(
+    aggregate.breakAfterPeriod!,
+    aggregate.halftimeDurationMs
+  );
+}
+
+/** Button text: "Start Halftime", "Start End Q1", etc. */
+export function getStartBreakButtonLabel(
+  aggregate: Pick<
+    GameAggregate,
+    "breakPhase" | "breakAfterPeriod" | "halftimeDurationMs"
+  >
+): string | null {
+  const pending = getPendingBreakLabel(aggregate);
+  if (!pending) return null;
+  return `Start ${pending}`;
+}
+
+/** @deprecated Use isOnBreak + getBreakDisplayLabel */
 export function isHalftimeActive(
   aggregate: Pick<
     GameAggregate,
-    "status" | "currentPeriod" | "halftimeDurationMs" | "gameClock"
+    "status" | "currentPeriod" | "halftimeDurationMs" | "gameClock" | "breakPhase"
   >
 ): boolean {
+  if (aggregate.breakPhase === "HALFTIME") return true;
   if (aggregate.status === "FINAL") return false;
   if (aggregate.currentPeriod !== 3) return false;
   const halftimeMs = aggregate.halftimeDurationMs ?? 5 * 60 * 1000;
   const clockDur = aggregate.gameClock?.durationMs;
   return clockDur != null && Math.abs(clockDur - halftimeMs) < 500;
+}
+
+/** Human label: "End Q1", "Halftime", "End Q3", etc. */
+export function getBreakDisplayLabel(
+  aggregate: Pick<
+    GameAggregate,
+    "breakPhase" | "breakAfterPeriod" | "halftimeDurationMs"
+  >
+): string | null {
+  if (!isOnBreak(aggregate)) return null;
+  if (aggregate.breakPhase === "HALFTIME") return "Halftime";
+  const after = aggregate.breakAfterPeriod;
+  if (after != null && after >= 1) return `End Q${after}`;
+  return null;
+}
+
+/** Shot clock display during break — always 00. */
+export function formatShotClockDuringBreak(): string {
+  return "0";
+}
+
+/** Remaining break time from game clock (authoritative during breaks). */
+export function getBreakRemainingMs(
+  aggregate: Pick<GameAggregate, "breakPhase" | "gameClock">,
+  now: number = Date.now()
+): number {
+  if (!isOnBreak(aggregate) || !aggregate.gameClock) return 0;
+  return getEffectiveRemainingMs(aggregate.gameClock, now);
 }
 
 /** Remaining time from server snapshot + running state (mirrors server/src/lib/clock). */
@@ -54,4 +172,9 @@ export function formatShotClockDisplay(ms: number): string {
     return `${m}:${String(s).padStart(2, "0")}`;
   }
   return String(Math.max(0, Math.ceil(totalSec - 1e-9)));
+}
+
+/** Break countdown on scoreboard/kiosk: m:ss for breaks (usually ≥ 1 min). */
+export function formatBreakCountdownDisplay(ms: number): string {
+  return formatGameTimeDisplay(ms);
 }

--- a/web-app/src/lib/gameProgressDisplay.ts
+++ b/web-app/src/lib/gameProgressDisplay.ts
@@ -15,10 +15,32 @@ export function isGameProgressRowHidden(eventType: string): boolean {
 
 type ProgressEvent = { eventType: string; payload?: unknown };
 
+/** Remark for QUARTER_ENDED rows (payload.afterPeriod = quarter that just ended). */
+export function formatQuarterEndedRemark(
+  payload: Record<string, unknown> | undefined
+): string {
+  const after = payload?.afterPeriod;
+  if (typeof after !== "number" || after < 1) return "Quarter ended";
+  if (after >= 5) return "OT Ended";
+  return `Q${after} Ended`;
+}
+
+/** Remark for GAME_CLOCK_STARTED rows (payload.period from server). */
+export function formatQuarterStartedRemark(
+  payload: Record<string, unknown> | undefined
+): string {
+  const period = payload?.period;
+  if (typeof period !== "number" || period < 1) return "Quarter started";
+  if (period >= 5) return "OT Started";
+  return `Q${period} Started`;
+}
+
 /**
- * One "Quarter started" per period: keep the first GAME_CLOCK_STARTED after each
+ * One quarter-start row per period: keep the first GAME_CLOCK_STARTED after each
  * PERIOD_ADVANCED (or for Q1 before any advance). Later clock resumes in the same
  * period are omitted from the table.
+ * PERIOD_ADVANCED with payload.fromBreak is omitted — "break ended" already marks `sq`
+ * after an active break; the event stays in full history for replays.
  */
 export function eventsForGameProgressDisplay<T extends ProgressEvent>(events: T[]): T[] {
   let seenQuarterStartForPeriod = false;
@@ -27,7 +49,10 @@ export function eventsForGameProgressDisplay<T extends ProgressEvent>(events: T[
   for (const ev of events) {
     if (ev.eventType === "PERIOD_ADVANCED") {
       seenQuarterStartForPeriod = false;
-      if (!isGameProgressRowHidden(ev.eventType)) {
+      const p = ev.payload as Record<string, unknown> | undefined;
+      // After `sq` from an active break we already show "break ended"; omit duplicate "End Q1 → Q2".
+      const omitFromTable = p?.fromBreak === true;
+      if (!isGameProgressRowHidden(ev.eventType) && !omitFromTable) {
         out.push(ev);
       }
       continue;

--- a/web-app/src/pages/GameSheet.tsx
+++ b/web-app/src/pages/GameSheet.tsx
@@ -2,12 +2,23 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import type { Socket } from "socket.io-client";
 import {
+  formatBreakCountdownDisplay,
+  formatGamePeriodFooter,
   formatGameTimeDisplay,
   formatShotClockDisplay,
+  formatShotClockDuringBreak,
+  getBreakDisplayLabel,
+  getBreakRemainingMs,
   getEffectiveRemainingMs,
-  isHalftimeActive,
+  getPendingBreakLabel,
+  isBreakPending,
+  isOnBreak,
 } from "../lib/clockDisplay";
-import { eventsForGameProgressDisplay } from "../lib/gameProgressDisplay";
+import {
+  eventsForGameProgressDisplay,
+  formatQuarterEndedRemark,
+  formatQuarterStartedRemark,
+} from "../lib/gameProgressDisplay";
 import { createGameSocket } from "../lib/socketUrl";
 import { api, type GameAggregate } from "../api/client";
 import { ApiErrorDisplay } from "../components/DatabaseUnavailable";
@@ -71,7 +82,17 @@ function goalEventDelta(payload: Record<string, unknown> | undefined): number {
 
 interface ParsedInput {
   raw: string;
-  type: "START_QUARTER" | "END_QUARTER" | "GOAL" | "EXCLUSION" | "PENALTY" | "TIMEOUT" | "TIMEOUT_30";
+  type:
+    | "START_QUARTER"
+    | "END_QUARTER"
+    | "START_BREAK"
+    | "TOGGLE_GAME_CLOCK"
+    | "RESET_SHOT_CLOCK"
+    | "GOAL"
+    | "EXCLUSION"
+    | "PENALTY"
+    | "TIMEOUT"
+    | "TIMEOUT_30";
   timeSeconds?: number;
   side?: TeamSide;
   capNumber?: string;
@@ -359,9 +380,8 @@ export function GameSheet() {
 
   const homeScore = aggregate.score?.homeScore ?? 0;
   const awayScore = aggregate.score?.awayScore ?? 0;
-  const isGameOver =
-    aggregate.status === "FINAL" ||
-    (aggregate.currentPeriod >= aggregate.totalPeriods && !aggregate.gameClock?.running);
+  /** Only block scoring when the game is officially final — not when the clock is simply stopped. */
+  const isGameOver = aggregate.status === "FINAL";
   const homeTimeouts = aggregate.timeoutStates?.find((t) => t.teamSide === "HOME");
   const awayTimeouts = aggregate.timeoutStates?.find((t) => t.teamSide === "AWAY");
 
@@ -467,7 +487,10 @@ export function GameSheet() {
         }
         break;
       case "GAME_CLOCK_STARTED":
-        remark = "Quarter started";
+        remark = formatQuarterStartedRemark(p);
+        break;
+      case "QUARTER_ENDED":
+        remark = formatQuarterEndedRemark(p);
         break;
       case "HORN_TRIGGERED":
         remark = "Horn";
@@ -479,7 +502,8 @@ export function GameSheet() {
         remark = ev.eventType.replace(/_/g, " ").toLowerCase();
     }
     const isQuarterStart = ev.eventType === "GAME_CLOCK_STARTED";
-    const isQuarterEnd = ev.eventType === "PERIOD_ADVANCED";
+    const isQuarterEnd =
+      ev.eventType === "PERIOD_ADVANCED" || ev.eventType === "QUARTER_ENDED";
     const foulCount =
       ev.eventType === "EXCLUSION_STARTED" && side && cap
         ? (foulsByPlayer[(side as TeamSide)]?.[cap]?.length ?? 0)
@@ -786,13 +810,23 @@ export function GameSheet() {
 
   void tick;
   const now = Date.now();
-  const halftimeActive = isHalftimeActive(aggregate);
-  const gameClockDisplay = aggregate.gameClock
-    ? formatGameTimeDisplay(getEffectiveRemainingMs(aggregate.gameClock, now))
-    : "—";
-  const shotClockDisplay = aggregate.shotClock
-    ? formatShotClockDisplay(getEffectiveRemainingMs(aggregate.shotClock, now))
-    : "—";
+  const breakPending = isBreakPending(aggregate);
+  const pendingBreakLabel = getPendingBreakLabel(aggregate);
+  const onBreak = isOnBreak(aggregate);
+  const breakLabel = getBreakDisplayLabel(aggregate);
+  const breakMs = onBreak ? getBreakRemainingMs(aggregate, now) : 0;
+  const gameClockDisplay = onBreak
+    ? formatBreakCountdownDisplay(breakMs)
+    : aggregate.gameClock
+      ? formatGameTimeDisplay(getEffectiveRemainingMs(aggregate.gameClock, now))
+      : "—";
+  const shotClockDisplay = onBreak
+    ? formatShotClockDuringBreak()
+    : aggregate.shotClock
+      ? formatShotClockDisplay(getEffectiveRemainingMs(aggregate.shotClock, now))
+      : "—";
+  const gameClockLabel = onBreak && breakLabel ? breakLabel : "Game";
+  const shotClockLabel = "Shot";
 
   return (
     <div className="page game-sheet-page">
@@ -881,10 +915,14 @@ export function GameSheet() {
                   </div>
                 </div>
               </div>
+              {breakPending && pendingBreakLabel ? (
+                <p className="scoreboard-break-pending-hint" role="status">
+                  {pendingBreakLabel} — type <strong>sb</strong> or use Timer to start break clock.
+                </p>
+              ) : null}
               <div className="scoreboard-footer">
                 <div className="scoreboard-footer-period">
-                  Period: Q{aggregate.currentPeriod}
-                  {halftimeActive ? " · HT" : null}
+                  {formatGamePeriodFooter(aggregate)}
                 </div>
                 <div className="scoreboard-footer-clocks" aria-live="polite">
                   <div
@@ -894,7 +932,7 @@ export function GameSheet() {
                         : "scoreboard-clock"
                     }
                   >
-                    <span className="scoreboard-clock-label">Game</span>
+                    <span className="scoreboard-clock-label">{gameClockLabel}</span>
                     <span className="scoreboard-clock-value">{gameClockDisplay}</span>
                   </div>
                   <div
@@ -904,7 +942,7 @@ export function GameSheet() {
                         : "scoreboard-clock"
                     }
                   >
-                    <span className="scoreboard-clock-label">Shot</span>
+                    <span className="scoreboard-clock-label">{shotClockLabel}</span>
                     <span className="scoreboard-clock-value">{shotClockDisplay}</span>
                   </div>
                 </div>
@@ -962,7 +1000,7 @@ export function GameSheet() {
             </form>
             {lastParsed && (
               <p className="parsed-preview">
-                Parsed: {describeParsed(lastParsed)}
+                Parsed: {describeParsed(lastParsed, aggregate)}
               </p>
             )}
           </section>
@@ -993,16 +1031,26 @@ export function GameSheet() {
                 <div className="scoring-command-help-body">
                   <h3>Quarter</h3>
                   <ul>
-                    <li><strong>sq</strong> — Start quarter (log only; use Timer for clock)</li>
-                    <li><strong>eq</strong> — End quarter</li>
+                    <li><strong>sq</strong> — Start next quarter (after break, ends break and advances period)</li>
+                    <li><strong>eq</strong> — End quarter (stops clocks; does not start break countdown)</li>
+                    <li><strong>sb</strong> or <strong>startbreak</strong> — Start break/halftime countdown (after <strong>eq</strong>)</li>
                   </ul>
+
+                  <h3>Clock</h3>
+                  <ul>
+                    <li><strong>c</strong> or <strong>clock</strong> — Start or stop the game clock</li>
+                    <li><strong>r</strong> or <strong>reset</strong> — Reset shot clock to full shot time (from game settings)</li>
+                  </ul>
+                  <p>
+                    After <strong>eq</strong>, use <strong>sb</strong> before <strong>c</strong> or <strong>r</strong> while break is pending.
+                  </p>
 
                   <h3>Time</h3>
                   <p>
                     Use a dot or colon: <strong>6.07</strong> or <strong>6:07</strong> = 6 min 7 sec.
                     Optional at the start of goals, exclusions, penalties, and timeouts. If omitted, the
-                    current <strong>game clock</strong> on the scoreboard is recorded. Does not change the
-                    live clock (use <strong>Timer</strong>).
+                    current <strong>game clock</strong> on the scoreboard is recorded. Scoring entries do not
+                    start or stop the live clock (use <strong>c</strong> or the Timer page).
                   </p>
 
                   <h3>Team</h3>
@@ -1027,8 +1075,11 @@ export function GameSheet() {
 
                   <h3>Examples</h3>
                   <ul className="scoring-command-help-examples">
-                    <li><code>sq</code> — start quarter (does not change clock)</li>
+                    <li><code>sq</code> — start next quarter</li>
                     <li><code>eq</code> — end quarter</li>
+                    <li><code>sb</code> — start break/halftime clock</li>
+                    <li><code>c</code> — toggle game clock (start/stop)</li>
+                    <li><code>r</code> — reset shot clock to full shot time</li>
                     <li><code>w13g</code> — Light cap 13 goal (current game clock)</li>
                     <li><code>6:50w13g</code> — Light cap 13 goal at 6:50</li>
                     <li><code>5.53b2e</code> — Dark cap 2 exclusion at 5:53</li>
@@ -1944,6 +1995,15 @@ function parseScoreInput(raw: string): { ok: true; value: ParsedInput } | { ok: 
   if (lower === "eq") {
     return { ok: true, value: { raw, type: "END_QUARTER" } };
   }
+  if (lower === "sb" || lower === "startbreak") {
+    return { ok: true, value: { raw, type: "START_BREAK" } };
+  }
+  if (lower === "c" || lower === "clock") {
+    return { ok: true, value: { raw, type: "TOGGLE_GAME_CLOCK" } };
+  }
+  if (lower === "r" || lower === "reset") {
+    return { ok: true, value: { raw, type: "RESET_SHOT_CLOCK" } };
+  }
 
   // b and d both mean dark; w and l both mean light
   const darkChars = "bd";
@@ -1989,7 +2049,7 @@ function parseScoreInput(raw: string): { ok: true; value: ParsedInput } | { ok: 
       return {
         ok: false,
         error:
-          "Invalid command. Examples: sq, eq, w13g, g13w, 6.07w13g, 5.53b2e, tw, 4.13tw or 4.13t3w.",
+          "Invalid command. Examples: sq, eq, sb, c, r, w13g, g13w, 6.07w13g, 5.53b2e, tw, 4.13tw or 4.13t3w.",
       };
     }
   }
@@ -2192,12 +2252,25 @@ function formatParsedTime(seconds?: number): string {
   return "current game clock";
 }
 
-function describeParsed(parsed: ParsedInput): string {
+function describeParsed(parsed: ParsedInput, aggregate: GameAggregate): string {
   switch (parsed.type) {
-    case "START_QUARTER":
-      return "Start quarter";
+    case "START_QUARTER": {
+      const cp = aggregate.currentPeriod;
+      const tp = aggregate.totalPeriods;
+      if (isOnBreak(aggregate) || isBreakPending(aggregate)) {
+        const next = Math.min(tp, cp + 1);
+        return next >= 5 ? "Start OT" : `Start Q${next}`;
+      }
+      return cp >= 5 ? "Start OT game clock" : `Start Q${cp} game clock`;
+    }
     case "END_QUARTER":
       return "End quarter";
+    case "START_BREAK":
+      return "Start break / halftime clock";
+    case "TOGGLE_GAME_CLOCK":
+      return aggregate.gameClock?.running ? "Stop game clock" : "Start game clock";
+    case "RESET_SHOT_CLOCK":
+      return "Reset shot clock to full shot time";
     case "TIMEOUT":
       return `${parsed.side === "HOME" ? "Dark" : "Light"} timeout at ${formatParsedTime(parsed.timeSeconds)}`;
     case "TIMEOUT_30":

--- a/web-app/src/pages/GameTimer.tsx
+++ b/web-app/src/pages/GameTimer.tsx
@@ -6,9 +6,17 @@ import { Settings } from "lucide-react";
 import { api, type GameAggregate } from "../api/client";
 import { ApiErrorDisplay, formatApiErrorMessage } from "../components/DatabaseUnavailable";
 import {
+  formatBreakCountdownDisplay,
   formatGameTimeDisplay,
   formatShotClockDisplay,
+  formatShotClockDuringBreak,
+  getBreakDisplayLabel,
+  getBreakRemainingMs,
   getEffectiveRemainingMs,
+  getGamePeriodSubtitle,
+  getStartBreakButtonLabel,
+  isBreakPending,
+  isOnBreak,
 } from "../lib/clockDisplay";
 import {
   formatGameTimeForInput,
@@ -163,12 +171,22 @@ export function GameTimer() {
 
   void tick; // re-render on interval while clocks run
   const now = Date.now();
-  const gameMs = aggregate.gameClock
-    ? getEffectiveRemainingMs(aggregate.gameClock, now)
-    : 0;
+  const breakPending = isBreakPending(aggregate);
+  const onBreak = isOnBreak(aggregate);
+  const breakLabel = getBreakDisplayLabel(aggregate);
+  const startBreakLabel = getStartBreakButtonLabel(aggregate);
+  const breakMs = onBreak ? getBreakRemainingMs(aggregate, now) : 0;
+  const gameMs = onBreak
+    ? breakMs
+    : aggregate.gameClock
+      ? getEffectiveRemainingMs(aggregate.gameClock, now)
+      : 0;
   const shotMs = aggregate.shotClock
     ? getEffectiveRemainingMs(aggregate.shotClock, now)
     : 0;
+  const shotDisplay = onBreak
+    ? formatShotClockDuringBreak()
+    : formatShotClockDisplay(shotMs);
 
   const toggleGameClock = () => {
     if (gameRunning) {
@@ -205,8 +223,7 @@ export function GameTimer() {
           </button>
         </div>
         <p className="game-timer-sub">
-          {aggregate.homeTeamName} vs {aggregate.awayTeamName} — Period {aggregate.currentPeriod} of{" "}
-          {aggregate.totalPeriods}
+          {aggregate.homeTeamName} vs {aggregate.awayTeamName} — {getGamePeriodSubtitle(aggregate)}
         </p>
         {error ? (
           <div className="game-timer-error" role="alert">
@@ -216,50 +233,68 @@ export function GameTimer() {
       </header>
 
       <div className="game-timer-displays" aria-live="polite">
-        <section className="game-timer-block" aria-label="Game time">
-          <h2 className="game-timer-block-label">Game time</h2>
+        <section
+          className="game-timer-block"
+          aria-label={onBreak && breakLabel ? breakLabel : "Game time"}
+        >
+          <h2 className="game-timer-block-label">
+            {onBreak && breakLabel ? breakLabel : "Game time"}
+          </h2>
           <div className="game-timer-digits game-timer-digits--game">
-            {formatGameTimeDisplay(gameMs)}
+            {onBreak ? formatBreakCountdownDisplay(gameMs) : formatGameTimeDisplay(gameMs)}
           </div>
         </section>
-        <section className="game-timer-block" aria-label="Shot clock">
+        <section className="game-timer-block" aria-label={onBreak ? "Shot clock off" : "Shot clock"}>
           <h2 className="game-timer-block-label">Shot clock</h2>
-          <div className="game-timer-digits game-timer-digits--shot">
-            {formatShotClockDisplay(shotMs)}
-          </div>
+          <div className="game-timer-digits game-timer-digits--shot">{shotDisplay}</div>
         </section>
       </div>
 
       <div className="game-timer-actions">
-        <button
-          type="button"
-          className={
-            "btn game-timer-startstop " +
-            (gameRunning ? "game-timer-startstop--running" : "game-timer-startstop--stopped")
-          }
-          disabled={busy}
-          onClick={toggleGameClock}
-        >
-          {gameRunning ? "Running" : "Start Clock"}
-        </button>
-        <div className="game-timer-shot-row">
+        {breakPending && startBreakLabel ? (
           <button
             type="button"
-            className="btn secondary game-timer-reset"
+            className="btn primary game-timer-start-break"
             disabled={busy}
-            onClick={() => void run(() => api.games.shotClockReset(gameId))}
+            onClick={() =>
+              void run(() => api.games.applyScoreCommand(gameId, { type: "START_BREAK" }))
+            }
           >
-            Reset shot clock
+            {startBreakLabel}
           </button>
+        ) : (
           <button
             type="button"
-            className="btn game-timer-undo"
-            disabled={busy}
-            onClick={() => void run(() => api.games.shotClockUndoReset(gameId))}
+            className={
+              "btn game-timer-startstop " +
+              (gameRunning ? "game-timer-startstop--running" : "game-timer-startstop--stopped")
+            }
+            disabled={busy || breakPending}
+            onClick={toggleGameClock}
           >
-            Undo
+            {gameRunning ? "Running" : "Start Clock"}
           </button>
-        </div>
+        )}
+        {!onBreak && !breakPending ? (
+          <div className="game-timer-shot-row">
+            <button
+              type="button"
+              className="btn secondary game-timer-reset"
+              disabled={busy}
+              onClick={() => void run(() => api.games.shotClockReset(gameId))}
+            >
+              Reset shot clock
+            </button>
+            <button
+              type="button"
+              className="btn game-timer-undo"
+              disabled={busy}
+              onClick={() => void run(() => api.games.shotClockUndoReset(gameId))}
+            >
+              Undo
+            </button>
+          </div>
+        ) : null}
       </div>
 
       {settingsOpen ? (

--- a/web-app/src/pages/KioskScoreboardDisplay.tsx
+++ b/web-app/src/pages/KioskScoreboardDisplay.tsx
@@ -4,7 +4,13 @@ import type { Socket } from "socket.io-client";
 import { api, type GameAggregate } from "../api/client";
 import { ApiErrorDisplay } from "../components/DatabaseUnavailable";
 import { useKioskDeviceCheckIn } from "../hooks/useKioskDeviceCheckIn";
-import { isHalftimeActive } from "../lib/clockDisplay";
+import {
+  formatBreakCountdownDisplay,
+  getBreakDisplayLabel,
+  getBreakRemainingMs,
+  isGameFinal,
+  isOnBreak,
+} from "../lib/clockDisplay";
 import { createGameSocket } from "../lib/socketUrl";
 
 type KioskScoreboardDisplayProps = {
@@ -18,6 +24,7 @@ export function KioskScoreboardDisplay(props: KioskScoreboardDisplayProps) {
   const [aggregate, setAggregate] = useState<GameAggregate | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
+  const [now, setNow] = useState(() => Date.now());
   useKioskDeviceCheckIn();
 
   useEffect(() => {
@@ -53,6 +60,15 @@ export function KioskScoreboardDisplay(props: KioskScoreboardDisplayProps) {
     };
   }, [gameId]);
 
+  const gameRunning = aggregate?.gameClock?.running ?? false;
+  const onBreak = aggregate != null && isOnBreak(aggregate);
+
+  useEffect(() => {
+    if (!onBreak && !gameRunning) return;
+    const id = window.setInterval(() => setNow(Date.now()), 100);
+    return () => window.clearInterval(id);
+  }, [onBreak, gameRunning]);
+
   if (loading) {
     return (
       <div className="kiosk-display-page kiosk-scoreboard-display">
@@ -79,26 +95,29 @@ export function KioskScoreboardDisplay(props: KioskScoreboardDisplayProps) {
   const awayScore = aggregate.score?.awayScore ?? 0;
   const tp = aggregate.totalPeriods;
   const cp = aggregate.currentPeriod;
-  const isFinal = aggregate.status === "FINAL";
+  const isFinal = isGameFinal(aggregate);
 
+  const halfTimeActive = aggregate.breakPhase === "HALFTIME";
   const inP3 = !isFinal && cp === 3;
-  const halfTimeActive = isHalftimeActive(aggregate);
-  const q3Active = inP3 && !halfTimeActive;
+  const q3Active = inP3 && !halfTimeActive && !onBreak;
 
   const phaseActive = {
-    q1: !isFinal && cp === 1,
-    q2: !isFinal && cp === 2,
+    q1: !isFinal && cp === 1 && !onBreak,
+    q2: !isFinal && cp === 2 && !onBreak,
     ht: halfTimeActive,
     q3: q3Active,
-    q4: !isFinal && cp === 4 && tp >= 4,
+    q4: !isFinal && cp === 4 && tp >= 4 && !onBreak,
     ot: !isFinal && cp === 5 && tp >= 5,
     final: isFinal,
   };
 
+  const breakLabel = getBreakDisplayLabel(aggregate);
+  const breakMs = onBreak ? getBreakRemainingMs(aggregate, now) : 0;
+
   return (
     <div
       className="kiosk-display-page kiosk-scoreboard-display"
-      aria-label={`${aggregate.homeTeamName} vs ${aggregate.awayTeamName}, period ${cp} of ${tp}`}
+      aria-label={`${aggregate.homeTeamName} vs ${aggregate.awayTeamName}, ${isFinal ? "final" : `period ${cp} of ${tp}`}`}
     >
       <div className="kiosk-display-columns">
         <section className="kiosk-display-side kiosk-display-side--dark" aria-label="Home">
@@ -115,15 +134,35 @@ export function KioskScoreboardDisplay(props: KioskScoreboardDisplayProps) {
 
       <section className="kiosk-display-periods" aria-label="Period">
         <div className="kiosk-display-period-row">
-          <span className={`kiosk-phase${phaseActive.q1 ? " is-active" : ""}`}>Q1</span>
-          <span className={`kiosk-phase${phaseActive.q2 ? " is-active" : ""}`}>Q2</span>
-          <span className={`kiosk-phase${phaseActive.ht ? " is-active" : ""}`}>HT</span>
-          <span className={`kiosk-phase${phaseActive.q3 ? " is-active" : ""}`}>Q3</span>
-          <span className={`kiosk-phase${phaseActive.q4 ? " is-active" : ""}`}>Q4</span>
-          <span className={`kiosk-phase${phaseActive.ot ? " is-active" : ""}`}>OT</span>
-          <span className={`kiosk-phase${phaseActive.final ? " is-active" : ""}`}>Final</span>
+          {isFinal ? (
+            <span className="kiosk-phase is-active">Final</span>
+          ) : (
+            <>
+              <span className={`kiosk-phase${phaseActive.q1 ? " is-active" : ""}`}>Q1</span>
+              <span className={`kiosk-phase${phaseActive.q2 ? " is-active" : ""}`}>Q2</span>
+              <span className={`kiosk-phase${phaseActive.ht ? " is-active" : ""}`}>HT</span>
+              <span className={`kiosk-phase${phaseActive.q3 ? " is-active" : ""}`}>Q3</span>
+              <span className={`kiosk-phase${phaseActive.q4 ? " is-active" : ""}`}>Q4</span>
+              <span className={`kiosk-phase${phaseActive.ot ? " is-active" : ""}`}>OT</span>
+            </>
+          )}
         </div>
       </section>
+
+      {onBreak && breakLabel ? (
+        <section className="kiosk-scoreboard-break" aria-live="polite">
+          <div className="kiosk-scoreboard-break-label">{breakLabel}</div>
+          <div
+            className={
+              gameRunning
+                ? "kiosk-scoreboard-break-time kiosk-scoreboard-break-time--running"
+                : "kiosk-scoreboard-break-time"
+            }
+          >
+            {formatBreakCountdownDisplay(breakMs)}
+          </div>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/web-app/src/pages/KioskShotClockDisplay.tsx
+++ b/web-app/src/pages/KioskShotClockDisplay.tsx
@@ -7,8 +7,11 @@ import { useKioskDeviceCheckIn } from "../hooks/useKioskDeviceCheckIn";
 import {
   formatGameTimeDisplay,
   formatShotClockDisplay,
+  formatShotClockDuringBreak,
+  getBreakDisplayLabel,
+  getBreakRemainingMs,
   getEffectiveRemainingMs,
-  isHalftimeActive,
+  isOnBreak,
 } from "../lib/clockDisplay";
 import { createGameSocket } from "../lib/socketUrl";
 
@@ -60,6 +63,7 @@ export function KioskShotClockDisplay(props: KioskShotClockDisplayProps) {
 
   const gameRunning = aggregate?.gameClock?.running ?? false;
   const shotRunning = aggregate?.shotClock?.running ?? false;
+  const onBreak = aggregate != null && isOnBreak(aggregate);
   const anyRunning = gameRunning || shotRunning;
 
   useEffect(() => {
@@ -90,25 +94,35 @@ export function KioskShotClockDisplay(props: KioskShotClockDisplayProps) {
     );
   }
 
-  const halftime = isHalftimeActive(aggregate);
+  const breakLabel = getBreakDisplayLabel(aggregate);
+  const breakMs = onBreak ? getBreakRemainingMs(aggregate, now) : 0;
   const gameMs = aggregate.gameClock
     ? getEffectiveRemainingMs(aggregate.gameClock, now)
     : 0;
   const shotMs = aggregate.shotClock
     ? getEffectiveRemainingMs(aggregate.shotClock, now)
     : 0;
-  const mainDisplayMs = halftime ? gameMs : shotMs;
+
+  if (onBreak && breakLabel) {
+    return (
+      <div className="kiosk-display-page kiosk-shotclock-display" aria-live="polite">
+        <div className="kiosk-shotclock-game" aria-label={`${breakLabel} remaining`}>
+          {formatGameTimeDisplay(breakMs)}
+        </div>
+        <div className="kiosk-shotclock-shot kiosk-shotclock-break-label" aria-label="Shot clock">
+          {formatShotClockDuringBreak()}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="kiosk-display-page kiosk-shotclock-display" aria-live="polite">
       <div className="kiosk-shotclock-game" aria-label="Game time">
         {formatGameTimeDisplay(gameMs)}
       </div>
-      <div
-        className="kiosk-shotclock-shot"
-        aria-label={halftime ? "Halftime remaining" : "Shot clock"}
-      >
-        {formatShotClockDisplay(mainDisplayMs)}
+      <div className="kiosk-shotclock-shot" aria-label="Shot clock">
+        {formatShotClockDisplay(shotMs)}
       </div>
     </div>
   );

--- a/web-app/src/pages/KioskTimerDisplay.tsx
+++ b/web-app/src/pages/KioskTimerDisplay.tsx
@@ -8,6 +8,7 @@ import {
   formatGameTimeDisplay,
   formatShotClockDisplay,
   getEffectiveRemainingMs,
+  getGamePeriodSubtitle,
 } from "../lib/clockDisplay";
 import { createGameSocket } from "../lib/socketUrl";
 
@@ -101,8 +102,7 @@ export function KioskTimerDisplay(props: KioskTimerDisplayProps) {
       <header className="kiosk-display-header">
         <h1 className="kiosk-display-title kiosk-timer-title">Timer</h1>
         <p className="kiosk-display-meta">
-          {aggregate.homeTeamName} vs {aggregate.awayTeamName} — Period {aggregate.currentPeriod} of{" "}
-          {aggregate.totalPeriods}
+          {aggregate.homeTeamName} vs {aggregate.awayTeamName} — {getGamePeriodSubtitle(aggregate)}
         </p>
       </header>
       <div className="kiosk-timer-blocks" aria-live="polite">

--- a/web-app/src/pages/ScoreboardControl.tsx
+++ b/web-app/src/pages/ScoreboardControl.tsx
@@ -4,6 +4,7 @@ import type { Socket } from "socket.io-client";
 import { createGameSocket } from "../lib/socketUrl";
 import { api, type GameAggregate } from "../api/client";
 import { ApiErrorDisplay } from "../components/DatabaseUnavailable";
+import { isOnBreak } from "../lib/clockDisplay";
 
 export function ScoreboardControl() {
   const { id: gameDayId, gameId } = useParams<{ id: string; gameId: string }>();
@@ -12,8 +13,6 @@ export function ScoreboardControl() {
   const [error, setError] = useState<unknown>(null);
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);
-  /** Server only has currentPeriod 3 for both; track which label the operator last chose. */
-  const [period3Choice, setPeriod3Choice] = useState<"half" | "q3" | null>(null);
 
   useEffect(() => {
     if (!gameId) return;
@@ -42,12 +41,6 @@ export function ScoreboardControl() {
       }
     };
   }, [gameId]);
-
-  useEffect(() => {
-    if (aggregate?.currentPeriod !== 3) {
-      setPeriod3Choice(null);
-    }
-  }, [aggregate?.currentPeriod]);
 
   const run = useCallback(async (fn: () => Promise<GameAggregate>) => {
     if (!gameId || busyRef.current) return;
@@ -92,15 +85,17 @@ export function ScoreboardControl() {
   const tp = aggregate.totalPeriods;
   const cp = aggregate.currentPeriod;
   const isFinal = aggregate.status === "FINAL";
+  const periodHeading = isFinal ? "Final" : "Period";
+  const onBreak = isOnBreak(aggregate);
 
+  const halfTimeActive = aggregate.breakPhase === "HALFTIME";
   const inP3 = !isFinal && cp === 3;
-  const halfTimeActive = inP3 && period3Choice === "half";
-  const q3Active = inP3 && (period3Choice === "q3" || period3Choice === null);
+  const q3Active = inP3 && !halfTimeActive && !onBreak;
 
   const phaseActive = {
-    q1: !isFinal && cp === 1,
-    q2: !isFinal && cp === 2,
-    q4: !isFinal && cp === 4 && tp >= 4,
+    q1: !isFinal && cp === 1 && !onBreak,
+    q2: !isFinal && cp === 2 && !onBreak,
+    q4: !isFinal && cp === 4 && tp >= 4 && !onBreak,
     ot: !isFinal && cp === 5 && tp >= 5,
     final: isFinal,
   };
@@ -184,86 +179,93 @@ export function ScoreboardControl() {
       </div>
 
       <section className="scoreboard-control-period" aria-label="Quarter or game phase">
-        <h2 className="scoreboard-control-period-heading">Period</h2>
+        <h2 className="scoreboard-control-period-heading">{periodHeading}</h2>
         <div className="scoreboard-control-period-grid">
-          <button
-            type="button"
-            className={`btn scoreboard-control-phase-btn${phaseActive.q1 ? " is-active" : ""}`}
-            disabled={busy || tp < 1}
-            onClick={() => run(() => api.games.setPeriod(gameId, 1))}
-          >
-            Q1
-          </button>
-          <button
-            type="button"
-            className={`btn scoreboard-control-phase-btn${phaseActive.q2 ? " is-active" : ""}`}
-            disabled={busy || tp < 2}
-            onClick={() => run(() => api.games.setPeriod(gameId, 2))}
-          >
-            Q2
-          </button>
-          <button
-            type="button"
-            className={`btn scoreboard-control-phase-btn${halfTimeActive ? " is-active" : ""}`}
-            disabled={busy || tp < 3}
-            onClick={() =>
-              run(async () => {
-                const next = await api.games.setPeriod(gameId, 3);
-                setPeriod3Choice("half");
-                return next;
-              })
-            }
-          >
-            Half time
-          </button>
-          <button
-            type="button"
-            className={`btn scoreboard-control-phase-btn${q3Active ? " is-active" : ""}`}
-            disabled={busy || tp < 3}
-            onClick={() =>
-              run(async () => {
-                const next = await api.games.setPeriod(gameId, 3);
-                setPeriod3Choice("q3");
-                return next;
-              })
-            }
-          >
-            Q3
-          </button>
-          <button
-            type="button"
-            className={`btn scoreboard-control-phase-btn${phaseActive.q4 ? " is-active" : ""}`}
-            disabled={busy || tp < 4}
-            onClick={() => run(() => api.games.setPeriod(gameId, 4))}
-          >
-            Q4
-          </button>
-          <button
-            type="button"
-            className={`btn scoreboard-control-phase-btn${phaseActive.ot ? " is-active" : ""}`}
-            disabled={busy || isFinal || tp < 4}
-            onClick={() => run(() => api.games.setPeriod(gameId, 5))}
-            title="Overtime (expands to a 5th period if still in regulation)"
-          >
-            OT
-          </button>
-          <button
-            type="button"
-            className={`btn scoreboard-control-phase-btn${phaseActive.final ? " is-active" : ""}`}
-            disabled={busy}
-            onClick={() =>
-              run(async () => {
-                await api.games.setPeriod(gameId, tp);
-                return api.games.update(gameId, { status: "FINAL" });
-              })
-            }
-          >
-            Final
-          </button>
+          {isFinal ? (
+            <button
+              type="button"
+              className="btn scoreboard-control-phase-btn is-active"
+              disabled={busy}
+              onClick={() =>
+                run(async () => {
+                  await api.games.setPeriod(gameId, tp);
+                  return api.games.update(gameId, { status: "FINAL" });
+                })
+              }
+            >
+              Final
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                className={`btn scoreboard-control-phase-btn${phaseActive.q1 ? " is-active" : ""}`}
+                disabled={busy || tp < 1}
+                onClick={() => run(() => api.games.setPeriod(gameId, 1))}
+              >
+                Q1
+              </button>
+              <button
+                type="button"
+                className={`btn scoreboard-control-phase-btn${phaseActive.q2 ? " is-active" : ""}`}
+                disabled={busy || tp < 2}
+                onClick={() => run(() => api.games.setPeriod(gameId, 2))}
+              >
+                Q2
+              </button>
+              <button
+                type="button"
+                className={`btn scoreboard-control-phase-btn${halfTimeActive ? " is-active" : ""}`}
+                disabled={busy || tp < 3}
+                onClick={() => run(() => api.games.setPeriod(gameId, 2, { halftime: true }))}
+              >
+                Half time
+              </button>
+              <button
+                type="button"
+                className={`btn scoreboard-control-phase-btn${q3Active ? " is-active" : ""}`}
+                disabled={busy || tp < 3}
+                onClick={() => run(() => api.games.setPeriod(gameId, 3))}
+              >
+                Q3
+              </button>
+              <button
+                type="button"
+                className={`btn scoreboard-control-phase-btn${phaseActive.q4 ? " is-active" : ""}`}
+                disabled={busy || tp < 4}
+                onClick={() => run(() => api.games.setPeriod(gameId, 4))}
+              >
+                Q4
+              </button>
+              <button
+                type="button"
+                className={`btn scoreboard-control-phase-btn${phaseActive.ot ? " is-active" : ""}`}
+                disabled={busy || tp < 4}
+                onClick={() => run(() => api.games.setPeriod(gameId, 5))}
+                title="Overtime (expands to a 5th period if still in regulation)"
+              >
+                OT
+              </button>
+              <button
+                type="button"
+                className={`btn scoreboard-control-phase-btn${phaseActive.final ? " is-active" : ""}`}
+                disabled={busy}
+                onClick={() =>
+                  run(async () => {
+                    await api.games.setPeriod(gameId, tp);
+                    return api.games.update(gameId, { status: "FINAL" });
+                  })
+                }
+              >
+                Final
+              </button>
+            </>
+          )}
         </div>
         <p className="scoreboard-control-period-note">
-          Half time and Q3 both set period 3. Q4 is the last regulation quarter. OT adds period 5 (or
-          selects it if already in overtime). Final ends the game.
+          Half time starts the halftime break after Q2 (scores stay on the board). Q3 clears halftime
+          and selects the third quarter. On the game sheet, <strong>eq</strong> ends a quarter;{" "}
+          <strong>sb</strong> or the Timer starts the break clock. Q4 is the last regulation quarter.
         </p>
       </section>
     </div>


### PR DESCRIPTION
# Fix #63 - Quarter Break and Halftime Workflow

## Summary

Fixes #63 by introducing a dedicated quarter-break workflow. Ending a quarter now transitions cleanly into a break state, and both game and shot clocks are reset appropriately when play resumes, preventing regulation time from remaining on the scoreboard between periods.

## What Changed

### Quarter / Break Flow

- `eq` (**End Quarter**)
  - Stops both the game clock and shot clock.
  - Records a `QUARTER_ENDED` event.
  - Does **not** automatically start the break countdown.

- `sb` / `startbreak`
  - Starts the quarter-break or halftime timer.
  - Records a `BREAK_STARTED` event.
  - Loads the configured break duration onto the game clock.

- `sq` (**Start Quarter**)
  - When a break is active:
    - Ends the break.
    - Advances the period.
    - Resets clocks for the new quarter.
  - When a break is pending (after `eq` but before `sb`):
    - Skips the break entirely.
    - Advances directly to the next quarter.

- Halftime support now uses the same break workflow.
  - Halftime occurs automatically after Q2.
  - Uses the configured halftime duration when defined.

### API & Data Model

#### New Enums

- `BreakPhase`
  - `NONE`
  - `QUARTER_BREAK`
  - `HALFTIME`

#### New Game Fields

- `breakAfterPeriod`
- `shotClockDurationMs`

#### New Event Types

- `QUARTER_ENDED`
- `BREAK_STARTED`
- `BREAK_ENDED`

#### New Score Commands

- `START_BREAK` (`sb`)
- `TOGGLE_GAME_CLOCK` (`c`)
- `RESET_SHOT_CLOCK` (`r`)

#### Validation Changes

- After `eq`, the following commands are rejected until the break begins:
  - `c`
  - `r`
- Users must either:
  - Start the break with `sb`, or
  - Use the Timer interface to begin the break.

#### State Rebuild

- `gameEventRerun` has been updated to correctly rebuild game state using the new break-related events.

### UI

The following interfaces now display break-aware status indicators:

- Game Sheet
- Timer
- Scoreboard Control
- Kiosk Displays

Supported states include:

- Break Pending
- On Break
- Halftime

#### Shared Utilities

Added shared helpers in:

- `clockDisplay.ts`
- `gameProgressDisplay.ts`

These provide:

- Phase display text
- Break-state formatting
- Consistent UI behavior across applications

### Tooling & Documentation

#### Prisma Client

- Prisma client is now generated under:

  ```text
  api/src/generated/prisma
  ```

- Added a post-generation copy step to support Docker builds.

#### Documentation Updates

Updated:

- `COMMAND_LIST.md`
  - Documents `eq`, `sb`, `sq`
  - Documents clock shortcuts
- `API/README.md`
- Setup and deployment notes

## Migrations

Run Prisma migrations before deployment:

- `add_break_phase`
- `add_quarter_ended_event`